### PR TITLE
Fix conditions to determine when onboarding should run on install/upgrade

### DIFF
--- a/debian/pt-web-portal-desktop.postinst
+++ b/debian/pt-web-portal-desktop.postinst
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 onboarding_should_run() {
-	notifications_file="/usr/lib/pt-web-portal/bak/usr/share/dbus-1/services/org.xfce.xfce4-notifyd.Notifications.service"
-	if [[ -f "${notifications_file}" ]]; then
+	DBUS_NOTIFICATION_SERVICE_FILE="/usr/lib/pt-web-portal/bak/usr/share/dbus-1/services/org.xfce.xfce4-notifyd.Notifications.service"
+	if [[ -f "${DBUS_NOTIFICATION_SERVICE_FILE}" ]]; then
 		return 0
 	fi
 	return 1

--- a/debian/pt-web-portal-desktop.preinst
+++ b/debian/pt-web-portal-desktop.preinst
@@ -16,10 +16,9 @@ unmask_pt_device_registration_service() {
 	systemctl unmask pt-device-registration
 }
 
-is_package_installed() {
-	package_name=$1
-	status="$(dpkg-query -W --showformat='${db:Status-Status}' "${package_name}" 2>&1)"
-	if [ "${status}" == "installed" ]; then
+is_fs_expanded() {
+	FS_EXPANDED_BREADCRUMB="/etc/pi-top/.expandedFs"
+	if [[ -f "${FS_EXPANDED_BREADCRUMB}" ]]; then
 		return 0
 	fi
 	return 1
@@ -63,7 +62,7 @@ upgrade)
 	;;
 
 install)
-	if is_pi_top_os && ! is_package_installed "pt-os-setup"; then
+	if is_pi_top_os && ! is_fs_expanded; then
 		prepare_for_onboarding
 	fi
 


### PR DESCRIPTION
Update maintainer scripts conditions to determine when the onboarding should run or not:

- If installing on a clean OS (when building a new pi-topOS image), system is setup to run onboarding on reboot.
- If installing `pt-web-portal` in an old version of pi-topOS, replacing `pt-os-setup`, onboarding already run and won't run again.
- If installing `pt-web-portal`in non pi-topOS OS, onboarding won't run.
