### PR TITLE
API sends error 400 on no data

### DIFF
--- a/src/server/backend/routes.py
+++ b/src/server/backend/routes.py
@@ -83,7 +83,7 @@ from .events import (
 
 def abort_on_no_data(data):
     if data is None:
-        abort(404)
+        abort(400)
     return jdumps(data)
 
 


### PR DESCRIPTION
API will respond w/error 400 on no data, instead of error 404.

Responding with error 404 on no data caused a bug, where the server sent back the index page to our onboarding, which of course we don't want, and the react app didn't know how to manage this. 

This happens because we're using error 404 to be able to manage & access the react app defined routes, via:
```
@app.errorhandler(404)
def not_found(e):
    return app.send_static_file('index.html')
```