### PR TITLE
pitopcommon -> pitop

### DIFF
--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -3,35 +3,35 @@ name: Run Tests and Upload Coverage Report
 on: push
 
 jobs:
-  test-and-upload-coverage-report:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2.3.4
+  #test-and-upload-coverage-report:
+  #  runs-on: ubuntu-20.04
+  #  steps:
+  #    - name: Checkout code
+  #      uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.7
+  #    - name: Setup Python
+  #      uses: actions/setup-python@v2.2.2
+  #      with:
+  #        python-version: 3.7
 
-      - name: Install pipenv
-        uses: dschep/install-pipenv-action@v1
+  #    - name: Install pipenv
+  #      uses: dschep/install-pipenv-action@v1
 
-      - name: Run Python tests and generate coverage report
-        run: |
-          cd src/server
-          pipenv install --dev
-          PYTHONPATH=backend pipenv run pytest --verbose --cov-report term-missing --cov=backend
-          pipenv run coverage xml
+  #    - name: Run Python tests and generate coverage report
+  #      run: |
+  #        cd src/server
+  #        pipenv install --dev
+  #        PYTHONPATH=backend pipenv run pytest --verbose --cov-report term-missing --cov=backend
+  #        pipenv run coverage xml
 
-      - name: Upload Python test coverage reports to Codecov
-        uses: codecov/codecov-action@v2.0.2
-        with:
-          files: ./src/server/coverage.xml
-          flags: unittests
-          env_vars: OS,PYTHON
-          fail_ci_if_error: true
-          verbose: true
+  #    - name: Upload Python test coverage reports to Codecov
+  #      uses: codecov/codecov-action@v2.0.2
+  #      with:
+  #        files: ./src/server/coverage.xml
+  #        flags: unittests
+  #        env_vars: OS,PYTHON
+  #        fail_ci_if_error: true
+  #        verbose: true
 
   test-js-coverage-report:
     runs-on: ubuntu-20.04

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = PIL,backend,flask,flask_cors,flask_sockets,gevent,geventwebsocket,pitop,pitopcommon,pytest,requests,websockets
+known_third_party = PIL,backend,flask,flask_cors,flask_sockets,gevent,geventwebsocket,pitop,pytest,requests,websockets

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Depends:
  python3-gevent,
  python3-gevent-websocket,
 # Used for PTLogger
- python3-pitopcommon,
+ python3-pitop,
  python3-waitress,
  python3-websockets,
  raspi-config,

--- a/src/miniscreen/onboarding/app.py
+++ b/src/miniscreen/onboarding/app.py
@@ -5,7 +5,7 @@ from time import sleep
 
 from PIL import Image, ImageDraw
 from pitop import Pitop
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .helpers import get_image_file_path
 from .menus import ApMenuPage, EthernetMenuPage, InfoMenuPage, Menus, UsbMenuPage

--- a/src/miniscreen/onboarding/connection_methods.py
+++ b/src/miniscreen/onboarding/connection_methods.py
@@ -3,8 +3,8 @@ from enum import Enum, auto
 from getpass import getuser
 from ipaddress import ip_address
 
-from pitopcommon.pt_os import is_pi_using_default_password
-from pitopcommon.sys_info import (
+from pitop.common.pt_os import is_pi_using_default_password
+from pitop.common.sys_info import (
     get_address_for_ptusb_connected_device,
     get_ap_mode_status,
     get_internal_ip,

--- a/src/server/Pipfile
+++ b/src/server/Pipfile
@@ -9,9 +9,8 @@ Flask = "*"
 Flask-Cors = "*"
 Flask-Sockets = "*"
 gevent-websocket = "*"
-pitopcommon = "*"
-pywifi = "*"
 websockets = "*"
+pitop = "*"
 
 [dev-packages]
 pytest = "*"

--- a/src/server/Pipfile.lock
+++ b/src/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0f83c6f27f8e3315d0205ec4c8a69c9138a95da86e261a22ebd2b3e143ac524b"
+            "sha256": "8334c52a6b4c7b51bd32e79f954bedb22202159f21ca878de825fd370c8b29b2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -36,11 +36,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060",
-                "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"
+                "sha256:1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55",
+                "sha256:a6209ca15eb63fc9385f38e452704113d679511d9574d09b2cf9183ae7d20dc9"
             ],
             "index": "pypi",
-            "version": "==1.1.2"
+            "version": "==2.0.1"
         },
         "flask-cors": {
             "hashes": [
@@ -163,12 +163,6 @@
             "markers": "python_version < '3.8'",
             "version": "==4.6.3"
         },
-        "isc-dhcp-leases": {
-            "hashes": [
-                "sha256:ee5e7d1ce49d5c0dc176ffbb4b90d914a459b25fffaec99e8e7ba3fa1e9a3e09"
-            ],
-            "version": "==0.9.1"
-        },
         "itsdangerous": {
             "hashes": [
                 "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
@@ -225,63 +219,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         },
-        "netifaces": {
-            "hashes": [
-                "sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32",
-                "sha256:08e3f102a59f9eaef70948340aeb6c89bd09734e0dca0f3b82720305729f63ea",
-                "sha256:0f6133ac02521270d9f7c490f0c8c60638ff4aec8338efeff10a1b51506abe85",
-                "sha256:18917fbbdcb2d4f897153c5ddbb56b31fa6dd7c3fa9608b7e3c3a663df8206b5",
-                "sha256:2479bb4bb50968089a7c045f24d120f37026d7e802ec134c4490eae994c729b5",
-                "sha256:2650beee182fed66617e18474b943e72e52f10a24dc8cac1db36c41ee9c041b7",
-                "sha256:28f4bf3a1361ab3ed93c5ef360c8b7d4a4ae060176a3529e72e5e4ffc4afd8b0",
-                "sha256:3ecb3f37c31d5d51d2a4d935cfa81c9bc956687c6f5237021b36d6fdc2815b2c",
-                "sha256:469fc61034f3daf095e02f9f1bbac07927b826c76b745207287bc594884cfd05",
-                "sha256:48324183af7f1bc44f5f197f3dad54a809ad1ef0c78baee2c88f16a5de02c4c9",
-                "sha256:50721858c935a76b83dd0dd1ab472cad0a3ef540a1408057624604002fcfb45b",
-                "sha256:54ff6624eb95b8a07e79aa8817288659af174e954cca24cdb0daeeddfc03c4ff",
-                "sha256:5be83986100ed1fdfa78f11ccff9e4757297735ac17391b95e17e74335c2047d",
-                "sha256:5f9ca13babe4d845e400921973f6165a4c2f9f3379c7abfc7478160e25d196a4",
-                "sha256:73ff21559675150d31deea8f1f8d7e9a9a7e4688732a94d71327082f517fc6b4",
-                "sha256:7dbb71ea26d304e78ccccf6faccef71bb27ea35e259fb883cfd7fd7b4f17ecb1",
-                "sha256:815eafdf8b8f2e61370afc6add6194bd5a7252ae44c667e96c4c1ecf418811e4",
-                "sha256:841aa21110a20dc1621e3dd9f922c64ca64dd1eb213c47267a2c324d823f6c8f",
-                "sha256:84e4d2e6973eccc52778735befc01638498781ce0e39aa2044ccfd2385c03246",
-                "sha256:8f7da24eab0d4184715d96208b38d373fd15c37b0dafb74756c638bd619ba150",
-                "sha256:96c0fe9696398253f93482c84814f0e7290eee0bfec11563bd07d80d701280c3",
-                "sha256:aab1dbfdc55086c789f0eb37affccf47b895b98d490738b81f3b2360100426be",
-                "sha256:c03fb2d4ef4e393f2e6ffc6376410a22a3544f164b336b3a355226653e5efd89",
-                "sha256:c37a1ca83825bc6f54dddf5277e9c65dec2f1b4d0ba44b8fd42bc30c91aa6ea1",
-                "sha256:c92ff9ac7c2282009fe0dcb67ee3cd17978cffbe0c8f4b471c00fe4325c9b4d4",
-                "sha256:c9a3a47cd3aaeb71e93e681d9816c56406ed755b9442e981b07e3618fb71d2ac",
-                "sha256:cb925e1ca024d6f9b4f9b01d83215fd00fe69d095d0255ff3f64bffda74025c8",
-                "sha256:d07b01c51b0b6ceb0f09fc48ec58debd99d2c8430b09e56651addeaf5de48048",
-                "sha256:e76c7f351e0444721e85f975ae92718e21c1f361bda946d60a214061de1f00a1",
-                "sha256:eb4813b77d5df99903af4757ce980a98c4d702bbcb81f32a0b305a1537bdf0b1"
-            ],
-            "version": "==0.11.0"
-        },
-        "pitopcommon": {
-            "hashes": [
-                "sha256:5b0ae8a51a3993a062ae055482ae9bddfbf1c01779b55d9165e64b617d85f882",
-                "sha256:e514d11cd514c99b1ab2a6f142201bbed843289e9f7504f815515f1caae5f2ef"
-            ],
-            "index": "pypi",
-            "version": "==0.8.9"
-        },
-        "python-systemd": {
-            "hashes": [
-                "sha256:c01352a24518a6d89f90ceb94e384b0ef0385ea5b3b2d6963f8262d9c00f2fc7"
-            ],
-            "version": "==0.0.9"
-        },
-        "pywifi": {
-            "hashes": [
-                "sha256:6da15de5d573635a461a95919920788b6f61748e1bd93a5e3504f456cf2e8bcc",
-                "sha256:d1b79d9ff054eef1aca4ab97f2641650d001d6740bfa7666a7d9506bcfb8459b"
-            ],
-            "index": "pypi",
-            "version": "==1.1.12"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -301,31 +238,42 @@
         },
         "websockets": {
             "hashes": [
-                "sha256:0e4fb4de42701340bd2353bb2eee45314651caa6ccee80dbd5f5d5978888fed5",
-                "sha256:1d3f1bf059d04a4e0eb4985a887d49195e15ebabc42364f4eb564b1d065793f5",
-                "sha256:20891f0dddade307ffddf593c733a3fdb6b83e6f9eef85908113e628fa5a8308",
-                "sha256:295359a2cc78736737dd88c343cd0747546b2174b5e1adc223824bcaf3e164cb",
-                "sha256:2db62a9142e88535038a6bcfea70ef9447696ea77891aebb730a333a51ed559a",
-                "sha256:3762791ab8b38948f0c4d281c8b2ddfa99b7e510e46bd8dfa942a5fff621068c",
-                "sha256:3db87421956f1b0779a7564915875ba774295cc86e81bc671631379371af1170",
-                "sha256:3ef56fcc7b1ff90de46ccd5a687bbd13a3180132268c4254fc0fa44ecf4fc422",
-                "sha256:4f9f7d28ce1d8f1295717c2c25b732c2bc0645db3215cf757551c392177d7cb8",
-                "sha256:5c01fd846263a75bc8a2b9542606927cfad57e7282965d96b93c387622487485",
-                "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f",
-                "sha256:751a556205d8245ff94aeef23546a1113b1dd4f6e4d102ded66c39b99c2ce6c8",
-                "sha256:7ff46d441db78241f4c6c27b3868c9ae71473fe03341340d2dfdbe8d79310acc",
-                "sha256:965889d9f0e2a75edd81a07592d0ced54daa5b0785f57dc429c378edbcffe779",
-                "sha256:9b248ba3dd8a03b1a10b19efe7d4f7fa41d158fdaa95e2cf65af5a7b95a4f989",
-                "sha256:9bef37ee224e104a413f0780e29adb3e514a5b698aabe0d969a6ba426b8435d1",
-                "sha256:c1ec8db4fac31850286b7cd3b9c0e1b944204668b8eb721674916d4e28744092",
-                "sha256:c8a116feafdb1f84607cb3b14aa1418424ae71fee131642fc568d21423b51824",
-                "sha256:ce85b06a10fc65e6143518b96d3dca27b081a740bae261c2fb20375801a9d56d",
-                "sha256:d705f8aeecdf3262379644e4b55107a3b55860eb812b673b28d0fbc347a60c55",
-                "sha256:e898a0863421650f0bebac8ba40840fc02258ef4714cb7e1fd76b6a6354bda36",
-                "sha256:f8a7bff6e8664afc4e6c28b983845c5bc14965030e3fb98789734d416af77c4b"
+                "sha256:0dd4eb8e0bbf365d6f652711ce21b8fd2b596f873d32aabb0fbb53ec604418cc",
+                "sha256:1d0971cc7251aeff955aa742ec541ee8aaea4bb2ebf0245748fbec62f744a37e",
+                "sha256:1d6b4fddb12ab9adf87b843cd4316c4bd602db8d5efd2fb83147f0458fe85135",
+                "sha256:230a3506df6b5f446fed2398e58dcaafdff12d67fe1397dff196411a9e820d02",
+                "sha256:276d2339ebf0df4f45df453923ebd2270b87900eda5dfd4a6b0cfa15f82111c3",
+                "sha256:2cf04601633a4ec176b9cc3d3e73789c037641001dbfaf7c411f89cd3e04fcaf",
+                "sha256:3ddff38894c7857c476feb3538dd847514379d6dc844961dc99f04b0384b1b1b",
+                "sha256:48c222feb3ced18f3dc61168ca18952a22fb88e5eb8902d2bf1b50faefdc34a2",
+                "sha256:51d04df04ed9d08077d10ccbe21e6805791b78eac49d16d30a1f1fe2e44ba0af",
+                "sha256:597c28f3aa7a09e8c070a86b03107094ee5cdafcc0d55f2f2eac92faac8dc67d",
+                "sha256:5c8f0d82ea2468282e08b0cf5307f3ad022290ed50c45d5cb7767957ca782880",
+                "sha256:7189e51955f9268b2bdd6cc537e0faa06f8fffda7fb386e5922c6391de51b077",
+                "sha256:7df3596838b2a0c07c6f6d67752c53859a54993d4f062689fdf547cb56d0f84f",
+                "sha256:826ccf85d4514609219725ba4a7abd569228c2c9f1968e8be05be366f68291ec",
+                "sha256:836d14eb53b500fd92bd5db2fc5894f7c72b634f9c2a28f546f75967503d8e25",
+                "sha256:85db8090ba94e22d964498a47fdd933b8875a1add6ebc514c7ac8703eb97bbf0",
+                "sha256:85e701a6c316b7067f1e8675c638036a796fe5116783a4c932e7eb8e305a3ffe",
+                "sha256:900589e19200be76dd7cbaa95e9771605b5ce3f62512d039fb3bc5da9014912a",
+                "sha256:9147868bb0cc01e6846606cd65cbf9c58598f187b96d14dd1ca17338b08793bb",
+                "sha256:9e7fdc775fe7403dbd8bc883ba59576a6232eac96dacb56512daacf7af5d618d",
+                "sha256:ab5ee15d3462198c794c49ccd31773d8a2b8c17d622aa184f669d2b98c2f0857",
+                "sha256:ad893d889bc700a5835e0a95a3e4f2c39e91577ab232a3dc03c262a0f8fc4b5c",
+                "sha256:b2e71c4670ebe1067fa8632f0d081e47254ee2d3d409de54168b43b0ba9147e0",
+                "sha256:b43b13e5622c5a53ab12f3272e6f42f1ce37cd5b6684b2676cb365403295cd40",
+                "sha256:b4ad84b156cf50529b8ac5cc1638c2cf8680490e3fccb6121316c8c02620a2e4",
+                "sha256:be5fd35e99970518547edc906efab29afd392319f020c3c58b0e1a158e16ed20",
+                "sha256:caa68c95bc1776d3521f81eeb4d5b9438be92514ec2a79fececda814099c8314",
+                "sha256:d144b350045c53c8ff09aa1cfa955012dd32f00c7e0862c199edcabb1a8b32da",
+                "sha256:d2c2d9b24d3c65b5a02cac12cbb4e4194e590314519ed49db2f67ef561c3cf58",
+                "sha256:e9e5fd6dbdf95d99bc03732ded1fc8ef22ebbc05999ac7e0c7bf57fe6e4e5ae2",
+                "sha256:ebf459a1c069f9866d8569439c06193c586e72c9330db1390af7c6a0a32c4afd",
+                "sha256:f31722f1c033c198aa4a39a01905951c00bd1c74f922e8afc1b1c62adbcdd56a",
+                "sha256:f68c352a68e5fdf1e97288d5cec9296664c590c25932a8476224124aaf90dbcd"
             ],
             "index": "pypi",
-            "version": "==8.1"
+            "version": "==9.1"
         },
         "werkzeug": {
             "hashes": [
@@ -419,39 +367,61 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:16db4173575901db8f3e6cc05e50fe19c7849b0256f6dc2e0979485184053417",
-                "sha256:18183948d5480e2ae30ad67edddf748149c778592b7e4ee649c058d5de2dcbb1",
-                "sha256:22888d3ce1b6fa1125f0be1602d8c634e00e7ec3a87bdb594ad87bde0b00b2b6",
-                "sha256:23c1611471cbfa2ac0e283862a76a333c13e5e7c4d499feb9919a5f52884610e",
-                "sha256:2dcc6d62b69a82759e5dddd788e09dd329124e493e62d92cfd01c0b918d7e511",
-                "sha256:40e30139113b141c238620b700aa5bd5c1b3a7b29ae47398936ff1c9166109d9",
-                "sha256:4528368196a90f11b70fb5668c13d92e88ba795eb4d37aab5855fd0479db417b",
-                "sha256:4cbdc51fc8c00ec6e53b30221d5757034aecf9839761bf97eaec0db7f0ff4955",
-                "sha256:6a585ba4087cc1fb5bfe34d1ecaaee183b854427992be2b42f1722ba8289fa82",
-                "sha256:79c136327e90ee46a2b3094263df94da5212890d6145678741eb805d79714971",
-                "sha256:7beec4df7542cf681356ef243fee3bf948775fc0d125bdcad3508e834229e07d",
-                "sha256:8394626a07e0a1b3695a16a4548d32e7259e00817d4bab1ef8172a1bd82a724e",
-                "sha256:84a1000f622d1df8824cd1ac629aa8392679c5c4de3f0de9e6889373f99ff3a0",
-                "sha256:91cd79f0f2996a4de737de89fdcbcd379a5bfd7b15129378ad1e5fc234e58d33",
-                "sha256:951e8d7bc98bceb61fc4fb426966fae854160301c0f8cd0945c62f2504f68615",
-                "sha256:95d2293d6a60da8952c675050231c02c9f4f1c1b9cf916315173e921d137d683",
-                "sha256:9981294b131023e63061ba88f4498fe27b9b15d908079d1866ee66a63d6e793f",
-                "sha256:a8826f6ecf079cb648534790ba59218a64e12a59bf2cd9ff00199abb39864a79",
-                "sha256:c1630e847ae0a2a366f18ddc3e017b69f80d729e95830579c61b5f9e9b94b91e",
-                "sha256:c6f46d5bbec8fe1ff25215356e819528a90d84b2801703514746b665742f1cd2",
-                "sha256:c8099c7033fb1ca73ac2246c3e52f45dd6a9c3826c59b3b5ad94e5be4e08d99b",
-                "sha256:ceb872b89c6461d4365be5f8fbf14f867be6b5217760980de7e014e54648f8ef",
-                "sha256:d6fbe69d52628b3e8a144265fd134f5da07cf287a00cf529730ae10380d315b2",
-                "sha256:da7de6e4162c69cc03cc56b7d051ae11147ac30872ff57df4ba4cac6d70ce5d9",
-                "sha256:ddb2287f66500ac57b24cce60341074b148977b74cd20eca755f95262928086f",
-                "sha256:e6a4260f0abf90c023b4f838905f645695b31666b76837152e2befad3d1ef5d6",
-                "sha256:e97b387f2744762b9984639b59abd7abb46ea6ae2ea24cb7c07893612328559b",
-                "sha256:ea784c96ca3b94912176d7adc9c4bb7d1988f36a0223a9ac128f4c834775202c",
-                "sha256:f0b250a03891255feb3ae69ac29d05cf9a62f5869bb8bac0e7f4968e7274efac",
-                "sha256:fdaa96733c9cf85491ad406fd78aa16025a1ea468951545b3da7ee133c150c7a"
+                "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
+                "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
+                "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45",
+                "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a",
+                "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03",
+                "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529",
+                "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a",
+                "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a",
+                "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2",
+                "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6",
+                "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759",
+                "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53",
+                "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a",
+                "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4",
+                "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff",
+                "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502",
+                "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793",
+                "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb",
+                "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905",
+                "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821",
+                "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b",
+                "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81",
+                "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0",
+                "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b",
+                "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3",
+                "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184",
+                "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701",
+                "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a",
+                "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82",
+                "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638",
+                "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5",
+                "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083",
+                "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6",
+                "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90",
+                "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465",
+                "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a",
+                "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3",
+                "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e",
+                "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066",
+                "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf",
+                "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b",
+                "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae",
+                "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669",
+                "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873",
+                "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b",
+                "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6",
+                "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb",
+                "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160",
+                "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c",
+                "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079",
+                "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
+                "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==6.0b1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==5.5"
         },
         "importlib-metadata": {
             "hashes": [
@@ -478,11 +448,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:265a94bf44ca13662f12fcd1b074c14d4b269a712f051b6f644ef7e705d6735f",
-                "sha256:467f0219e89bb5061a8429c6fc5cf055fa3983a0e68e84a1d205046306b37d9e"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.0.0.dev0"
+            "version": "==0.13.1"
         },
         "py": {
             "hashes": [
@@ -494,43 +464,43 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:1c6409312ce2ce2997896af5756753778d5f1603666dba5587804f09ad82ed27",
-                "sha256:f4896b4cc085a1f8f8ae53a1a90db5a86b3825ff73eb974dffee3d9e701007f4"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.0.0b2"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
-                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
             "index": "pypi",
-            "version": "==6.2.3"
+            "version": "==6.2.4"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
-                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
+                "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a",
+                "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"
             ],
             "index": "pypi",
-            "version": "==2.11.1"
+            "version": "==2.12.1"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e",
-                "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"
+                "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3",
+                "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"
             ],
             "index": "pypi",
-            "version": "==3.5.1"
+            "version": "==3.6.1"
         },
         "testpath": {
             "hashes": [
-                "sha256:60e0a3261c149755f4399a1fff7d37523179a70fdc3abdf78de9fc2604aeec7e",
-                "sha256:bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"
+                "sha256:1acf7a0bcd3004ae8357409fc33751e16d37ccc650921da1094a86581ad1e417",
+                "sha256:8044f9a0bab6567fc644a3593164e872543bb44225b0e24846e2c89237937589"
             ],
             "index": "pypi",
-            "version": "==0.4.4"
+            "version": "==0.5.0"
         },
         "toml": {
             "hashes": [

--- a/src/server/backend/events.py
+++ b/src/server/backend/events.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 from json import dumps as jdumps
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 
 class MessageType(Enum):

--- a/src/server/backend/helpers/about.py
+++ b/src/server/backend/helpers/about.py
@@ -2,7 +2,7 @@ from json import load as jload
 from re import match
 from typing import Dict
 
-from pitopcommon.common_names import DeviceName
+from pitop.common.common_names import DeviceName
 
 
 def _get_file_lines(filename) -> list:

--- a/src/server/backend/helpers/build.py
+++ b/src/server/backend/helpers/build.py
@@ -1,6 +1,6 @@
 from json import dumps
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .paths import pt_issue
 

--- a/src/server/backend/helpers/command_runner.py
+++ b/src/server/backend/helpers/command_runner.py
@@ -2,7 +2,7 @@ from os import environ
 from shlex import split
 from subprocess import Popen, run
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 
 def run_command_background(command_str: str) -> Popen:

--- a/src/server/backend/helpers/device_registration.py
+++ b/src/server/backend/helpers/device_registration.py
@@ -5,7 +5,7 @@ from threading import Thread
 from time import sleep
 
 import requests
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .finalise import onboarding_completed
 

--- a/src/server/backend/helpers/expand_fs.py
+++ b/src/server/backend/helpers/expand_fs.py
@@ -1,6 +1,6 @@
 from os import path
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .paths import expand_fs_breadcrumb

--- a/src/server/backend/helpers/finalise.py
+++ b/src/server/backend/helpers/finalise.py
@@ -2,9 +2,9 @@ from fileinput import input as finput
 from os import remove, utime
 from pathlib import Path
 
-from pitopcommon.command_runner import run_command_background
-from pitopcommon.current_session_info import get_user_using_display
-from pitopcommon.logger import PTLogger
+from pitop.common.command_runner import run_command_background
+from pitop.common.current_session_info import get_user_using_display
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .paths import boot_cmdline_txt, etc_pi_top, use_test_path

--- a/src/server/backend/helpers/keyboard.py
+++ b/src/server/backend/helpers/keyboard.py
@@ -1,7 +1,7 @@
 from fileinput import input as finput
 from typing import Optional, Tuple
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .paths import default_keyboard_conf

--- a/src/server/backend/helpers/language.py
+++ b/src/server/backend/helpers/language.py
@@ -1,7 +1,7 @@
 from re import search
 from typing import List
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .paths import default_locale, locales_gen, supported_locales

--- a/src/server/backend/helpers/os_updater.py
+++ b/src/server/backend/helpers/os_updater.py
@@ -1,7 +1,7 @@
 import os
 from datetime import date
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from ..events import MessageType
 from .modules import get_apt

--- a/src/server/backend/helpers/registration.py
+++ b/src/server/backend/helpers/registration.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .paths import etc_pi_top, pi_top_registration_txt
 

--- a/src/server/backend/helpers/system.py
+++ b/src/server/backend/helpers/system.py
@@ -1,5 +1,5 @@
-from pitopcommon.command_runner import run_command
-from pitopcommon.logger import PTLogger
+from pitop.common.command_runner import run_command
+from pitop.common.logger import PTLogger
 
 
 def restart_web_portal_service() -> None:

--- a/src/server/backend/helpers/system_clock.py
+++ b/src/server/backend/helpers/system_clock.py
@@ -1,6 +1,6 @@
 from time import sleep
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .wifi_manager import is_connected_to_internet

--- a/src/server/backend/helpers/timezone.py
+++ b/src/server/backend/helpers/timezone.py
@@ -1,4 +1,4 @@
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .paths import use_test_path, zone_tab

--- a/src/server/backend/helpers/tour.py
+++ b/src/server/backend/helpers/tour.py
@@ -1,9 +1,9 @@
 from os import remove
 from pathlib import Path
 
-from pitopcommon.command_runner import run_command_background
-from pitopcommon.current_session_info import get_user_using_display
-from pitopcommon.logger import PTLogger
+from pitop.common.command_runner import run_command_background
+from pitop.common.current_session_info import get_user_using_display
+from pitop.common.logger import PTLogger
 
 from .about import device_serial_number
 from .command_runner import run_command

--- a/src/server/backend/helpers/wifi_country.py
+++ b/src/server/backend/helpers/wifi_country.py
@@ -1,4 +1,4 @@
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .paths import iso_countries

--- a/src/server/backend/helpers/wifi_manager.py
+++ b/src/server/backend/helpers/wifi_manager.py
@@ -2,7 +2,7 @@ from enum import Enum
 from time import sleep
 from typing import Dict, List
 
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from .command_runner import run_command
 from .modules import get_pywifi

--- a/src/server/backend/routes.py
+++ b/src/server/backend/routes.py
@@ -5,7 +5,7 @@ from threading import Thread
 from flask import abort
 from flask import current_app as app
 from flask import redirect, request
-from pitopcommon.logger import PTLogger
+from pitop.common.logger import PTLogger
 
 from . import sockets
 from .events import (

--- a/src/server/run.py
+++ b/src/server/run.py
@@ -8,9 +8,9 @@ from backend.helpers.device_registration import register_device_in_background
 from backend.helpers.finalise import onboarding_completed
 from gevent import pywsgi
 from geventwebsocket.handler import WebSocketHandler
-from pitopcommon.command_runner import run_command
-from pitopcommon.logger import PTLogger
-from pitopcommon.sys_info import get_systemd_active_state, stop_systemd_service
+from pitop.common.command_runner import run_command
+from pitop.common.logger import PTLogger
+from pitop.common.sys_info import get_systemd_active_state, stop_systemd_service
 
 from miniscreen.onboarding.app import OnboardingApp
 


### PR DESCRIPTION
Update references to `pitopcommon`, which was merged to the SDK.

This PR breaks the python tests. Created #190  to tackle this issue later on.