### PR TITLE
Display upgrade message history while updating packages

### DIFF
--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -42,7 +42,7 @@ jobs:
       # Workaround: At the moment, only lock files in the project root are
       # supported...
       # https://github.com/actions/setup-node#caching-packages-dependencies
-      - run: cp src/frontend/yarn.lock .
+      - run: cp frontend/yarn.lock .
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload javascript test coverage reports to Codecov
         uses: codecov/codecov-action@v2.0.2
         with:
-          files: ./src/frontend/coverage/clover.xml
+          files: ./frontend/coverage/clover.xml
           flags: jstests
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run Node tests
         run: |
-          cd src/frontend
+          cd frontend
           yarn install
           yarn test --coverage
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '^.*\.snap$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/frontend/src/components/atoms/textarea/TextArea.module.css
+++ b/frontend/src/components/atoms/textarea/TextArea.module.css
@@ -1,0 +1,17 @@
+.root {
+
+}
+
+.textarea {
+    composes: fontBodyLarge from '../../../globalStyles/Typography.module.css';
+    background: none;
+    box-sizing: border-box;
+    min-height: 1rem;
+    padding: 2rem;
+    width: 100%;
+}
+
+.textarea:focus,
+.textarea:active {
+    /* outline: none !important; */
+}

--- a/frontend/src/components/atoms/textarea/TextArea.module.css
+++ b/frontend/src/components/atoms/textarea/TextArea.module.css
@@ -13,5 +13,5 @@
 
 .textarea:focus,
 .textarea:active {
-    /* outline: none !important; */
+
 }

--- a/frontend/src/components/atoms/textarea/TextArea.tsx
+++ b/frontend/src/components/atoms/textarea/TextArea.tsx
@@ -11,20 +11,12 @@ export type Props = {
     defaultValue?: string;
 };
 
-export type State = {
-    value: string;
-};
 
-
-export default class TextArea extends React.Component<Props, State> {
+export default class TextArea extends React.Component<Props> {
     element: HTMLTextAreaElement | null
-    state: State
 
     constructor(props: Props) {
         super(props);
-        this.state = {
-            value: this.props.defaultValue || ""
-        };
         this.element = null;
     }
 

--- a/frontend/src/components/atoms/textarea/TextArea.tsx
+++ b/frontend/src/components/atoms/textarea/TextArea.tsx
@@ -1,0 +1,60 @@
+import React, { ReactNode } from 'react';
+// import cx from 'classnames';
+
+// import styles from './TextArea.module.css';
+
+export type Props = {
+    children?: ReactNode;
+    className: string,
+    onChange?: () => null,
+    value: string,
+    disabled?: boolean;
+    autoScroll?: boolean;
+    defaultValue?: string;
+};
+
+export type State = {
+    value: string;
+};
+
+// export default ({ children, className, onChange, disabled, value, ...props }: Props) => (
+//   <div className={cx(styles.root, className)}>
+//     <textarea
+//       disabled={disabled}
+//       className={cx(styles.textarea, className)}
+//       onChange={onChange}
+//       value={value}
+//       {...props}
+//     />
+//   </div>
+// );
+
+export default class TextArea extends React.Component<Props, State> {
+    element: HTMLTextAreaElement | null
+    state: State
+
+    constructor(props: Props) {
+        super(props);
+        this.state = {
+            value: this.props.defaultValue || ""
+        };
+        this.element = null;
+    }
+
+    componentDidMount() {
+        if (this.element && this.props.autoScroll !== false) {
+            this.element.scrollTop = this.element.scrollHeight
+        }
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (prevProps.value !== this.props.value && this.element && this.props.autoScroll !== false) {
+            this.element.scrollTop = this.element.scrollHeight
+        }
+    }
+
+    render() {
+        return <textarea {...this.props} ref={e => this.element = e} />
+    }
+
+}

--- a/frontend/src/components/atoms/textarea/TextArea.tsx
+++ b/frontend/src/components/atoms/textarea/TextArea.tsx
@@ -1,7 +1,5 @@
 import React, { ReactNode } from 'react';
-// import cx from 'classnames';
 
-// import styles from './TextArea.module.css';
 
 export type Props = {
     children?: ReactNode;
@@ -17,17 +15,6 @@ export type State = {
     value: string;
 };
 
-// export default ({ children, className, onChange, disabled, value, ...props }: Props) => (
-//   <div className={cx(styles.root, className)}>
-//     <textarea
-//       disabled={disabled}
-//       className={cx(styles.textarea, className)}
-//       onChange={onChange}
-//       value={value}
-//       {...props}
-//     />
-//   </div>
-// );
 
 export default class TextArea extends React.Component<Props, State> {
     element: HTMLTextAreaElement | null
@@ -54,7 +41,12 @@ export default class TextArea extends React.Component<Props, State> {
     }
 
     render() {
-        return <textarea {...this.props} ref={e => this.element = e} />
+        return <textarea
+            className={this.props.className}
+            onChange={this.props.onChange}
+            value={this.props.value}
+            disabled={this.props.disabled}
+            defaultValue={this.props.defaultValue}
+            ref={e => this.element = e} />
     }
-
 }

--- a/frontend/src/components/atoms/textarea/TextArea.tsx
+++ b/frontend/src/components/atoms/textarea/TextArea.tsx
@@ -34,6 +34,7 @@ export default class TextArea extends React.Component<Props> {
 
     render() {
         return <textarea
+            data-testid="textarea"
             className={this.props.className}
             onChange={this.props.onChange}
             value={this.props.value}

--- a/frontend/src/components/buildInformation/__tests__/__snapshots__/BuildInformation.test.tsx.snap
+++ b/frontend/src/components/buildInformation/__tests__/__snapshots__/BuildInformation.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`BuildInformation when build info exists renders correctly 1`] = `
     class="root"
     data-testid="build-info"
   >
-    Build Number:
+    Build Number: 
     100
     <br />
-    Build Date:
+    Build Date: 
     2021-08-09
     <br />
-    Build Apt Repo:
+    Build Apt Repo: 
     experimental-pkgcld
     <br />
   </div>

--- a/frontend/src/components/onboarding_app/__tests__/__snapshots__/App.test.tsx.snap
+++ b/frontend/src/components/onboarding_app/__tests__/__snapshots__/App.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`App renders build information correctly when loaded 1`] = `
   class="root"
   data-testid="build-info"
 >
-  Build Number:
+  Build Number: 
   100
   <br />
-  Build Date:
+  Build Date: 
   2021-08-09
   <br />
-  Build Apt Repo:
+  Build Apt Repo: 
   experimental-pkgcld
   <br />
 </div>

--- a/frontend/src/pages/countryPage/__tests__/__snapshots__/CountryPage.test.tsx.snap
+++ b/frontend/src/pages/countryPage/__tests__/__snapshots__/CountryPage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`CountryPage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  Ok, now where
+  Ok, now where 
   <span
     class="green"
   >

--- a/frontend/src/pages/errorPage/__tests__/__snapshots__/ErrorPage.test.tsx.snap
+++ b/frontend/src/pages/errorPage/__tests__/__snapshots__/ErrorPage.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ErrorPage renders correctly 1`] = `
       <h1
         class="prompt"
       >
-        I've had some
+        I've had some 
         <span
           class="green"
         >
@@ -37,7 +37,7 @@ exports[`ErrorPage renders correctly 1`] = `
         class="explanation"
       >
         Please restart me by using the switch shown and contact
-
+         
         <span
           class="green"
         >
@@ -47,7 +47,7 @@ exports[`ErrorPage renders correctly 1`] = `
       <span
         class="explanation"
       >
-        If you are using a
+        If you are using a 
         <span
           class="green"
         >

--- a/frontend/src/pages/keyboardPage/__tests__/__snapshots__/KeyboardPage.test.tsx.snap
+++ b/frontend/src/pages/keyboardPage/__tests__/__snapshots__/KeyboardPage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`KeyboardPage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  QWERTY,
+  QWERTY, 
   <span
     class="green"
   >

--- a/frontend/src/pages/languagePage/__tests__/__snapshots__/LanguagePage.test.tsx.snap
+++ b/frontend/src/pages/languagePage/__tests__/__snapshots__/LanguagePage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`LanguagePage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  Me too! What
+  Me too! What 
   <span
     class="green"
   >

--- a/frontend/src/pages/registrationPage/__tests__/__snapshots__/RegistrationPage.test.tsx.snap
+++ b/frontend/src/pages/registrationPage/__tests__/__snapshots__/RegistrationPage.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`RegistrationPage renders prompt correctly 1`] = `
   class="prompt"
 >
   Hey, would you like to be kept
-
+   
   <span
     class="green"
   >

--- a/frontend/src/pages/restartPage/__tests__/__snapshots__/RestartPage.test.tsx.snap
+++ b/frontend/src/pages/restartPage/__tests__/__snapshots__/RestartPage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`RestartPage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  Right, I need a quick
+  Right, I need a quick 
   <span
     class="green"
   >

--- a/frontend/src/pages/splashPage/__tests__/__snapshots__/SplashPage.test.tsx.snap
+++ b/frontend/src/pages/splashPage/__tests__/__snapshots__/SplashPage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SplashPage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  Are you ready to be a
+  Are you ready to be a 
   <span
     class="green"
   >

--- a/frontend/src/pages/termsPage/__tests__/__snapshots__/TermsPage.test.tsx.snap
+++ b/frontend/src/pages/termsPage/__tests__/__snapshots__/TermsPage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`TermsPage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  OK, here are our
+  OK, here are our 
   <span
     class="green"
   >

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -154,7 +154,7 @@ export default ({
           <UpgradeHistoryTextArea message={parseMessage(message)} />
         }
 
-        { (waitingForServer || !(upgradeIsPrepared || error)) && (
+        { (waitingForServer && !error ) && (
           <>
             <Spinner size={40} />{" "}
           </>

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -146,11 +146,11 @@ export default ({
         onClose={() => setIsNewOsDialogActive(false)}
       />
 
-        { message && message?.type === OSUpdaterMessageType.Upgrade &&
+        { !waitingForServer && message && message?.type === OSUpdaterMessageType.Upgrade &&
           <UpgradeHistoryTextArea message={parseMessage(message)} />
         }
 
-        { message && message?.type === OSUpdaterMessageType.PrepareUpgrade &&
+        { !waitingForServer && message && message?.type === OSUpdaterMessageType.PrepareUpgrade &&
           <UpgradeHistoryTextArea message={parseMessage(message)} />
         }
 
@@ -161,7 +161,7 @@ export default ({
         )}
 
         {(message?.type === OSUpdaterMessageType.PrepareUpgrade || message?.type === OSUpdaterMessageType.Upgrade) && !waitingForServer && !error && (
-          <div className={styles.progress}>
+          <div data-testid="progress" className={styles.progress}>
             <ProgressBar
               percent={message.payload.percent}
               strokeWidth={2}

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -3,6 +3,7 @@ import { Line as ProgressBar } from "rc-progress";
 import prettyBytes from "pretty-bytes";
 
 import Layout from "../../components/layout/Layout";
+import Spinner from "../../components/atoms/spinner/Spinner";
 
 import upgradePage from "../../assets/images/upgrade-page.png";
 import styles from "./UpgradePage.module.css";
@@ -152,6 +153,12 @@ export default ({
         { message && message?.type === OSUpdaterMessageType.PrepareUpgrade &&
           <UpgradeHistoryTextArea message={parseMessage(message)} />
         }
+
+        { (waitingForServer || !(upgradeIsPrepared || error)) && (
+          <>
+            <Spinner size={40} />{" "}
+          </>
+        )}
 
         {(message?.type === OSUpdaterMessageType.PrepareUpgrade || message?.type === OSUpdaterMessageType.Upgrade) && !waitingForServer && !error && (
           <div className={styles.progress}>

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -118,7 +118,8 @@ export default ({ goToNextPage, goToPreviousPage, isCompleted }: Props) => {
     }
 
     if (
-      (message.type === OSUpdaterMessageType.PrepareUpgrade || message.type === OSUpdaterMessageType.Upgrade) && message.payload?.percent
+      (message.type === OSUpdaterMessageType.PrepareUpgrade || message.type === OSUpdaterMessageType.Upgrade)
+      && message.payload?.percent
     ) {
         document.title = "[" + message.payload.percent + "%] pi-topOS System Update";
     }

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -57,6 +57,7 @@ export type Props = {
 export default ({ goToNextPage, goToPreviousPage, isCompleted }: Props) => {
   const [message, setMessage] = useState<OSUpdaterMessage>();
   const [isOpen, setIsOpen] = useState(false);
+  document.title = "pi-topOS System Update"
 
   const socket = useSocket(`${wsBaseUrl}/os-upgrade`, );
   socket.onmessage = (e: MessageEvent) => {
@@ -114,6 +115,12 @@ export default ({ goToNextPage, goToPreviousPage, isCompleted }: Props) => {
   useEffect(() => {
     if (!message) {
       return;
+    }
+
+    if (
+      (message.type === OSUpdaterMessageType.PrepareUpgrade || message.type === OSUpdaterMessageType.Upgrade) && message.payload?.percent
+    ) {
+        document.title = "[" + message.payload.percent + "%] pi-topOS System Update";
     }
 
     if (

--- a/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
+++ b/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
@@ -5,7 +5,6 @@ import {
   RenderResult,
   waitForElement,
   wait,
-  queryByText,
   BoundFunction,
   QueryByBoundAttribute,
 } from "@testing-library/react";
@@ -52,7 +51,6 @@ const createServer = () => {
 
 describe("UpgradePageContainer", () => {
   let defaultProps: Props;
-  let queryByTestId: BoundFunction<QueryByBoundAttribute>;
   let mount: (props?: Props) => ExtendedRenderResult;
 
   beforeEach(async () => {
@@ -104,7 +102,6 @@ describe("UpgradePageContainer", () => {
       const result = render(<UpgradePageContainer {...props} />);
       return {
         ...result,
-        queryByTestId,
         waitForPreparation: () =>
           waitForElement(() =>
             result.getByText(

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -1,47 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UpgradePageContainer messages are displayed in the textarea component while preparing 1`] = `
-<textarea
-  class="textarea"
-  disabled=""
->
-  Preparing OS upgrade
-Finished preparing
-</textarea>
-`;
-
-exports[`UpgradePageContainer renders progress bar correctly 1`] = `
-<div
-  class="progress"
->
-  <svg
-    class="rc-progress-line "
-    preserveAspectRatio="none"
-    viewBox="0 0 100 2"
-  >
-    <path
-      class="rc-progress-line-trail"
-      d="M 1,1
-           L 99,1"
-      fill-opacity="0"
-      stroke="#D9D9D9"
-      stroke-linecap="round"
-      stroke-width="1"
-    />
-    <path
-      class="rc-progress-line-path"
-      d="M 1,1
-           L 99,1"
-      fill-opacity="0"
-      stroke="#71c0b4"
-      stroke-linecap="round"
-      stroke-width="2"
-      style="stroke-dasharray: 100px, 100px; stroke-dashoffset: -0px; transition: stroke-dashoffset 0.3s ease 0s, stroke-dasharray .3s ease 0s, stroke 0.3s linear; transition-duration: .3s, .3s, .3s, .06s;"
-    />
-  </svg>
-</div>
-`;
-
 exports[`UpgradePageContainer renders prompt correctly 1`] = `
 <h1
   class="prompt"
@@ -65,9 +23,20 @@ exports[`UpgradePageContainer renders the correct banner image 1`] = `
 />
 `;
 
-exports[`UpgradePageContainer when the upgrade fails renders the received messages in the textarea component 1`] = `
+exports[`UpgradePageContainer when preparation fails messages are displayed in the textarea component 1`] = `
 <textarea
   class="textarea"
+  data-testid="textarea"
+  disabled=""
+>
+  There was a problem during OS upgrade. Please continue, you'll be able to upgrade once the system reboots.
+</textarea>
+`;
+
+exports[`UpgradePageContainer when the upgrade fails messages are displayed in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  data-testid="textarea"
   disabled=""
 >
   Starting install & upgrade process
@@ -76,9 +45,22 @@ There was an error while upgrading packages.
 </textarea>
 `;
 
+exports[`UpgradePageContainer when the upgrade finishes messages are displayed in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  data-testid="textarea"
+  disabled=""
+>
+  Starting install & upgrade process
+dpkg-exec: Running dpkg
+Finished upgrade
+</textarea>
+`;
+
 exports[`UpgradePageContainer when the upgrade finishes renders progress bar correctly 1`] = `
 <div
   class="progress"
+  data-testid="progress"
 >
   <svg
     class="rc-progress-line "
@@ -108,20 +90,21 @@ exports[`UpgradePageContainer when the upgrade finishes renders progress bar cor
 </div>
 `;
 
-exports[`UpgradePageContainer when the upgrade finishes renders the received messages in the textarea component 1`] = `
+exports[`UpgradePageContainer when the upgrade is being installed messages are displayed in the textarea component 1`] = `
 <textarea
   class="textarea"
+  data-testid="textarea"
   disabled=""
 >
   Starting install & upgrade process
 dpkg-exec: Running dpkg
-Finished upgrade
 </textarea>
 `;
 
 exports[`UpgradePageContainer when the upgrade is being installed renders progress bar correctly 1`] = `
 <div
   class="progress"
+  data-testid="progress"
 >
   <svg
     class="rc-progress-line "
@@ -149,16 +132,6 @@ exports[`UpgradePageContainer when the upgrade is being installed renders progre
     />
   </svg>
 </div>
-`;
-
-exports[`UpgradePageContainer when the upgrade is being installed renders the received messages in the textarea component 1`] = `
-<textarea
-  class="textarea"
-  disabled=""
->
-  Starting install & upgrade process
-dpkg-exec: Running dpkg
-</textarea>
 `;
 
 exports[`UpgradePageContainer when there are major OS updates available and user 'requireBurn' renders the correct message 1`] = `
@@ -296,5 +269,48 @@ exports[`UpgradePageContainer when there are major OS updates available and user
       </div>
     </div>
   </div>
+</div>
+`;
+
+exports[`UpgradePageContainer while preparing updates messages are displayed in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  data-testid="textarea"
+  disabled=""
+>
+  Preparing OS upgrade
+</textarea>
+`;
+
+exports[`UpgradePageContainer while preparing updates renders progress bar correctly 1`] = `
+<div
+  class="progress"
+  data-testid="progress"
+>
+  <svg
+    class="rc-progress-line "
+    preserveAspectRatio="none"
+    viewBox="0 0 100 2"
+  >
+    <path
+      class="rc-progress-line-trail"
+      d="M 1,1
+           L 99,1"
+      fill-opacity="0"
+      stroke="#D9D9D9"
+      stroke-linecap="round"
+      stroke-width="1"
+    />
+    <path
+      class="rc-progress-line-path"
+      d="M 1,1
+           L 99,1"
+      fill-opacity="0"
+      stroke="#71c0b4"
+      stroke-linecap="round"
+      stroke-width="2"
+      style="stroke-dasharray: 0px, 100px; stroke-dashoffset: -0px; transition: stroke-dashoffset 0.3s ease 0s, stroke-dasharray .3s ease 0s, stroke 0.3s linear;"
+    />
+  </svg>
 </div>
 `;

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`UpgradePageContainer renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  OK, I need to be
+  OK, I need to be 
   <span
     class="green"
   >
@@ -173,7 +173,7 @@ exports[`UpgradePageContainer when there are major OS updates available and user
       <span
         class="osUpgradeWarning"
       >
-        For more information, go to
+        For more information, go to 
         <button
           class="unstyled link"
           type="button"
@@ -242,7 +242,7 @@ exports[`UpgradePageContainer when there are major OS updates available and user
       <span
         class="osUpgradeWarning"
       >
-        For more information, go to
+        For more information, go to 
         <button
           class="unstyled link"
           type="button"

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UpgradePageContainer messages are displayed in the textarea component while preparing 1`] = `
+<textarea
+  class="textarea"
+  disabled=""
+>
+  Preparing OS upgrade
+Finished preparing
+</textarea>
+`;
+
+exports[`UpgradePageContainer renders progress bar correctly 1`] = `
+<div
+  class="progress"
+>
+  <svg
+    class="rc-progress-line "
+    preserveAspectRatio="none"
+    viewBox="0 0 100 2"
+  >
+    <path
+      class="rc-progress-line-trail"
+      d="M 1,1
+           L 99,1"
+      fill-opacity="0"
+      stroke="#D9D9D9"
+      stroke-linecap="round"
+      stroke-width="1"
+    />
+    <path
+      class="rc-progress-line-path"
+      d="M 1,1
+           L 99,1"
+      fill-opacity="0"
+      stroke="#71c0b4"
+      stroke-linecap="round"
+      stroke-width="2"
+      style="stroke-dasharray: 100px, 100px; stroke-dashoffset: -0px; transition: stroke-dashoffset 0.3s ease 0s, stroke-dasharray .3s ease 0s, stroke 0.3s linear; transition-duration: .3s, .3s, .3s, .06s;"
+    />
+  </svg>
+</div>
+`;
+
 exports[`UpgradePageContainer renders prompt correctly 1`] = `
 <h1
   class="prompt"
@@ -21,6 +63,17 @@ exports[`UpgradePageContainer renders the correct banner image 1`] = `
   src="upgrade-page.png"
   style="max-height: 100%; max-width: 100%;"
 />
+`;
+
+exports[`UpgradePageContainer when the upgrade fails renders the received messages in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  disabled=""
+>
+  Starting install & upgrade process
+dpkg-exec: Running dpkg
+There was an error while upgrading packages.
+</textarea>
 `;
 
 exports[`UpgradePageContainer when the upgrade finishes renders progress bar correctly 1`] = `
@@ -52,12 +105,18 @@ exports[`UpgradePageContainer when the upgrade finishes renders progress bar cor
       style="stroke-dasharray: 0px, 100px; stroke-dashoffset: -0px; transition: stroke-dashoffset 0.3s ease 0s, stroke-dasharray .3s ease 0s, stroke 0.3s linear; transition-duration: 0s, 0s;"
     />
   </svg>
-  <span
-    class="message"
-  >
-    Finished upgrade
-  </span>
 </div>
+`;
+
+exports[`UpgradePageContainer when the upgrade finishes renders the received messages in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  disabled=""
+>
+  Starting install & upgrade process
+dpkg-exec: Running dpkg
+Finished upgrade
+</textarea>
 `;
 
 exports[`UpgradePageContainer when the upgrade is being installed renders progress bar correctly 1`] = `
@@ -89,11 +148,6 @@ exports[`UpgradePageContainer when the upgrade is being installed renders progre
       style="stroke-dasharray: 50px, 100px; stroke-dashoffset: -0px; transition: stroke-dashoffset 0.3s ease 0s, stroke-dasharray .3s ease 0s, stroke 0.3s linear; transition-duration: .3s, .3s, .3s, .06s;"
     />
   </svg>
-  <span
-    class="message"
-  >
-    dpkg-exec: Running dpkg
-  </span>
 </div>
 `;
 
@@ -233,4 +287,12 @@ exports[`UpgradePageContainer when there are major OS updates available and user
     </div>
   </div>
 </div>
+exports[`UpgradePageContainer when the upgrade is being installed renders the received messages in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  disabled=""
+>
+  Starting install & upgrade process
+dpkg-exec: Running dpkg
+</textarea>
 `;

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -151,6 +151,16 @@ exports[`UpgradePageContainer when the upgrade is being installed renders progre
 </div>
 `;
 
+exports[`UpgradePageContainer when the upgrade is being installed renders the received messages in the textarea component 1`] = `
+<textarea
+  class="textarea"
+  disabled=""
+>
+  Starting install & upgrade process
+dpkg-exec: Running dpkg
+</textarea>
+`;
+
 exports[`UpgradePageContainer when there are major OS updates available and user 'requireBurn' renders the correct message 1`] = `
 <div
   aria-pressed="false"
@@ -287,12 +297,4 @@ exports[`UpgradePageContainer when there are major OS updates available and user
     </div>
   </div>
 </div>
-exports[`UpgradePageContainer when the upgrade is being installed renders the received messages in the textarea component 1`] = `
-<textarea
-  class="textarea"
-  disabled=""
->
-  Starting install & upgrade process
-dpkg-exec: Running dpkg
-</textarea>
 `;

--- a/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextArea.module.css
+++ b/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextArea.module.css
@@ -1,0 +1,20 @@
+.textarea {
+  composes: text from '../../../globalStyles/Typography.module.css';
+  background: none;
+  /* border: none; */
+  box-sizing: border-box;
+  min-height: 1rem;
+  padding: 2rem;
+  width: 100%;
+  /* resize: none; */
+  /* outline: none; */
+
+  font-size: 16px;
+  color: var(--black, black);
+  /* overflow: hidden; */
+}
+
+.textarea:focus,
+.textarea:active {
+  /* outline: none; */
+}

--- a/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextArea.module.css
+++ b/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextArea.module.css
@@ -1,20 +1,17 @@
 .textarea {
   composes: text from '../../../globalStyles/Typography.module.css';
   background: none;
-  /* border: none; */
   box-sizing: border-box;
   min-height: 1rem;
-  padding: 2rem;
+
   width: 100%;
-  /* resize: none; */
-  /* outline: none; */
+  height: 30%;
 
-  font-size: 16px;
-  color: var(--black, black);
-  /* overflow: hidden; */
-}
+  padding: 5px;
+  resize: none;
+  outline: none;
 
-.textarea:focus,
-.textarea:active {
-  /* outline: none; */
+  font-size: 14px;
+  line-height: 120%;
+  color: var(--darkGrey, gray);
 }

--- a/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextArea.tsx
+++ b/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextArea.tsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from "react";
+import cx from 'classnames';
+
+import TextArea from "../../../components/atoms/textarea/TextArea";
+
+import styles from "./UpgradeHistoryTextArea.module.css";
+
+export type Props = {
+  className?: string;
+  message: string;
+};
+
+export default ({
+  className,
+  message,
+}: Props) => {
+  const [msg, setMsg] = useState<string[]>([]);
+
+  useEffect(() => {
+    setMsg(m => [...m, message])
+  }, [message]);
+
+  return (
+    <TextArea
+      className={cx(styles.textarea, className)}
+      value={msg.join("\n")}
+      disabled={true}
+      autoScroll={true}
+    />
+  );
+};

--- a/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextAreaContainer.tsx
+++ b/frontend/src/pages/upgradePage/upgradeHistoryTextArea/UpgradeHistoryTextAreaContainer.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import UpgradeHistoryTextArea from "./UpgradeHistoryTextArea";
+
+export type Props = {
+  className: string;
+  message: string;
+};
+
+export default ( props: Props) => {
+  return (
+    <UpgradeHistoryTextArea
+      {...props}
+    />
+  );
+};

--- a/frontend/src/pages/wifiPage/__tests__/__snapshots__/WifiPage.test.tsx.snap
+++ b/frontend/src/pages/wifiPage/__tests__/__snapshots__/WifiPage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`WifiPage renders prompt correctly 1`] = `
 <h1
   class="prompt"
 >
-  Connect me to
+  Connect me to 
   <span
     class="green"
   >
@@ -28,13 +28,13 @@ exports[`WifiPage when networks are passed when option without a password is sel
   class="messageContainer"
   data-testid="dialog-message"
 >
-  The WiFi network
+  The WiFi network 
   <span
     class="green"
   >
     unsecured-ssid
   </span>
-
+   
   does not require
    a password
 </h3>

--- a/frontend/src/pages/wifiPage/__tests__/__snapshots__/WifiPageContainer.test.tsx.snap
+++ b/frontend/src/pages/wifiPage/__tests__/__snapshots__/WifiPageContainer.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`WifiPageContainer when networks are loaded successfully when option wit
   class="messageContainer"
   data-testid="dialog-message"
 >
-  The WiFi network
+  The WiFi network 
   <span
     class="green"
   >
     password-protected-ssid
   </span>
-
+   
   requires
    a password
 </h3>

--- a/frontend/src/pages/wifiPage/connectDialog/__tests__/__snapshots__/ConnectDialog.test.tsx.snap
+++ b/frontend/src/pages/wifiPage/connectDialog/__tests__/__snapshots__/ConnectDialog.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`ConnectDialog when a password protected network is received renders dia
   class="messageContainer"
   data-testid="dialog-message"
 >
-  The WiFi network
+  The WiFi network 
   <span
     class="green"
   >
     network-name
   </span>
-
+   
   requires
    a password
 </h3>
@@ -22,13 +22,13 @@ exports[`ConnectDialog when an unprotected network is received renders dialog me
   class="messageContainer"
   data-testid="dialog-message"
 >
-  The WiFi network
+  The WiFi network 
   <span
     class="green"
   >
     unprotected-network
   </span>
-
+   
   does not require
    a password
 </h3>


### PR DESCRIPTION
### Summary

Display messages to user during upgrade process. 

The messages are provided by `python3-apt` to the backend, and sent to the frontend app using a websocket.

### Preview

![image](https://user-images.githubusercontent.com/14126805/132008822-40eb1b0d-7c54-4dfd-ab4f-249cd5e054ef.png)

![image](https://user-images.githubusercontent.com/14126805/132008865-555da224-49ce-4f6b-a985-b4e918f34dd4.png)
