### PR TITLE
Add description to errors on upgrade

### DIFF
--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -8,7 +8,7 @@ import Spinner from "../../components/atoms/spinner/Spinner";
 import upgradePage from "../../assets/images/upgrade-page.png";
 import styles from "./UpgradePage.module.css";
 
-import { OSUpdaterMessage, OSUpdaterMessageType } from "./UpgradePageContainer"
+import { OSUpdaterMessage, OSUpdaterMessageType, UpdateMessageStatus } from "./UpgradePageContainer"
 import NewOsVersionDialogContainer from "./newOsVersionDialog/NewOsVersionDialogContainer";
 import UpgradeHistoryTextArea from "../../components/upgradeHistoryTextArea/UpgradeHistoryTextArea";
 
@@ -80,7 +80,14 @@ export default ({
 
   const parseMessage = (message: OSUpdaterMessage) => {
     if (message?.type === OSUpdaterMessageType.UpdateSources || message?.type === OSUpdaterMessageType.Upgrade || message?.type === OSUpdaterMessageType.PrepareUpgrade) {
-      return JSON.stringify(message.payload?.message).trim().replace(/^"(.*)"$/, '$1');
+      let msg = JSON.stringify(message.payload?.message).trim().replace(/^"(.*)"$/, '$1')
+        .replace(/\\\\n/g, String.fromCharCode(10));
+      if (message.payload.status === UpdateMessageStatus.Error) {
+        // Add a newline before an ERROR message
+        msg = String.fromCharCode(13, 10) + msg;
+      }
+
+      return msg
     }
     return ""
   }

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`UpgradePageContainer when the system upgrade fails messages are display
 >
   Starting install & upgrade process
 dpkg-exec: Running dpkg
+
 There was an error while upgrading packages.
 </textarea>
 `;
@@ -281,6 +282,7 @@ exports[`UpgradePageContainer when updating sources fails messages are displayed
 >
   Starting to update sources
 Updating blah
+
 There was a problem updating sources
 </textarea>
 `;

--- a/pt_os_web_portal/os_updater/manager.py
+++ b/pt_os_web_portal/os_updater/manager.py
@@ -9,6 +9,13 @@ from .types import MessageType
 (apt, apt.progress, apt_pkg) = get_apt()
 
 
+class APTUpgradeException(Exception):
+    def __init__(self, packages_arr):
+        super().__init__(
+            f"Errors were encountered while processing: {''.join(packages_arr)}"
+        )
+
+
 class FetchProgress(apt.progress.base.AcquireProgress):  # type: ignore
     def __init__(self, callback):
         apt.progress.base.AcquireProgress.__init__(self)
@@ -40,6 +47,7 @@ class InstallProgress(apt.progress.base.InstallProgress):  # type: ignore
     def __init__(self, callback):
         apt.progress.base.InstallProgress.__init__(self)
         self.callback = callback
+        self.packages_with_errors = list()
 
     def status_change(self, pkg, percent, status):
         PTLogger.debug(f"Progress: {percent}% - {pkg}: {status}")
@@ -47,6 +55,14 @@ class InstallProgress(apt.progress.base.InstallProgress):  # type: ignore
 
     def update_interface(self):
         apt.progress.base.InstallProgress.update_interface(self)
+
+    def error(self, pkg, errormsg):
+        PTLogger.error(f"InstallProgress {pkg}: {errormsg}")
+        self.packages_with_errors.append(pkg)
+        # sent as MessageType.STATUS instead of MessageType.ERROR to avoid confusions,
+        # since several other messages are sent after this one
+        self.callback(MessageType.STATUS, f"ERROR - {pkg}: {errormsg}", 0)
+        super().error(pkg, errormsg)
 
 
 class OSUpdateManager:
@@ -146,8 +162,9 @@ class OSUpdateManager:
             self.cache.commit(fetch_packages_progress, install_progress)
             callback(MessageType.FINISH, "Finished upgrade", 100.0)
         except Exception as e:
-            PTLogger.error(f"OS Updater Error: {e}")
-            raise
+            if len(install_progress.packages_with_errors) > 0:
+                raise APTUpgradeException(install_progress.packages_with_errors)
+            raise e
         finally:
             self.lock = False
 

--- a/pt_os_web_portal/os_updater/manager.py
+++ b/pt_os_web_portal/os_updater/manager.py
@@ -12,8 +12,9 @@ from .types import MessageType
 
 class APTUpgradeException(Exception):
     def __init__(self, packages_arr: List):
+        formatted_packages = "\\n  - ".join(packages_arr)
         super().__init__(
-            f"Errors were encountered while processing: {''.join(packages_arr)}"
+            f"Errors were encountered while processing:\\n  - {formatted_packages}"
         )
 
 

--- a/pt_os_web_portal/os_updater/manager.py
+++ b/pt_os_web_portal/os_updater/manager.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from typing import List
 
 from pitop.common.logger import PTLogger
 
@@ -10,7 +11,7 @@ from .types import MessageType
 
 
 class APTUpgradeException(Exception):
-    def __init__(self, packages_arr):
+    def __init__(self, packages_arr: List):
         super().__init__(
             f"Errors were encountered while processing: {''.join(packages_arr)}"
         )


### PR DESCRIPTION
#### Summary

On system upgrade, some error messages were not sent to the frontend app, so there was no context to an update error. This PR will provide more detail to the (possible) errors on system upgrade, so that the logs displayed in the frontend app are similar to the output of `apt upgrade`. 

2 new messages are now sent:
- While installing the package, a message with the package name and the cause of the error.
- After the operations fails, a summary with the packages that caused the upgrade failure. This message is separated using a newline from the previous log messages.

#### Preview

![image](https://user-images.githubusercontent.com/14126805/133303672-74a59da1-5ec8-4138-baeb-6043ff5f5020.png)

The complete log shows:
```
Starting install & upgrade process
dpkg-exec: Running dpkg
notify-send-ng: Preparing notify-send-ng (armhf)
notify-send-ng: Unpacking notify-send-ng (armhf)
ERROR - /var/cache/apt/archives/notify-send-ng_1.2-4~4.gbp042e22_all.deb: trying to overwrite '/usr/bin/notify-action.sh', which is also in package notify-send.sh 1.0.0-3~1.gbpd6eeed
notify-send-ng: Installing notify-send-ng (armhf)
python3-pitop-full: Preparing python3-pitop-full (armhf)
python3-pitop-full: Unpacking python3-pitop-full (armhf)
python3-pitop-full: Installing python3-pitop-full (armhf)
python3-pitop: Preparing python3-pitop (armhf)
python3-pitop: Unpacking python3-pitop (armhf)
python3-pitop: Installing python3-pitop (armhf)
python3-pitop-doc: Preparing python3-pitop-doc (armhf)
python3-pitop-doc: Unpacking python3-pitop-doc (armhf)
python3-pitop-doc: Installing python3-pitop-doc (armhf)

Errors were encountered while processing:
  - /var/cache/apt/archives/notify-send-ng_1.2-4~4.gbp042e22_all.deb
```