### PR TITLE
Remove singleton for state

### DIFF
--- a/pt_os_web_portal/app.py
+++ b/pt_os_web_portal/app.py
@@ -1,3 +1,4 @@
+import state
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
 from pitop.common.common_names import DeviceName
@@ -11,19 +12,16 @@ from .miniscreen_onboarding_assistant.onboarding_assistant_app import (
     OnboardingAssistantApp,
 )
 from .os_updater import OSUpdater
-from .state import StateManager
 
 
 class App:
     def __init__(self, test_mode):
-        self.state_manager = StateManager()
-        self.os_updater = OSUpdater(self.state_manager)
+        self.os_updater = OSUpdater()
         self.wsgi_server = WSGIServer(
             ("", 80),
             create_app(
                 test_mode=test_mode,
                 os_updater=self.os_updater,
-                state_manager=self.state_manager,
             ),
             handler_class=WebSocketHandler,
         )
@@ -35,8 +33,7 @@ class App:
         self.os_updater.start()
 
         if (
-            self.state_manager.get("app", "state", fallback="onboarding")
-            == "onboarding"
+            state.get("app", "state", fallback="onboarding") == "onboarding"
             and device_type() == DeviceName.pi_top_4.value
         ):
             PTLogger.info(

--- a/pt_os_web_portal/backend/__init__.py
+++ b/pt_os_web_portal/backend/__init__.py
@@ -5,7 +5,7 @@ from flask_sockets import Sockets
 sockets: Sockets
 
 
-def create_app(test_mode, os_updater, state_manager):
+def create_app(test_mode, os_updater):
     app = Flask(
         __name__, static_url_path="", static_folder="./build", template_folder="./build"
     )
@@ -17,8 +17,6 @@ def create_app(test_mode, os_updater, state_manager):
         app.config["TESTING"] = True
     if os_updater:
         app.config["OS_UPDATER"] = os_updater
-    if state_manager:
-        app.config["STATE_MANAGER"] = state_manager
 
     with app.app_context():
         from . import routes

--- a/pt_os_web_portal/backend/helpers/finalise.py
+++ b/pt_os_web_portal/backend/helpers/finalise.py
@@ -1,16 +1,11 @@
 from os import path, remove
 
-from flask import current_app
 from pitop.common.command_runner import run_command, run_command_background
 from pitop.common.current_session_info import get_user_using_display
 from pitop.common.logger import PTLogger
 
+from ... import state
 from .paths import use_test_path
-
-
-def get_state_manager():
-    with current_app.app_context():
-        return current_app.config["STATE_MANAGER"]
 
 
 def available_space() -> str:
@@ -51,7 +46,7 @@ def deprioritise_openbox_session() -> None:
 def stop_onboarding_autostart() -> None:
     PTLogger.debug("Function: stop_onboarding_autostart()")
     remove("/etc/xdg/autostart/pt-os-setup.desktop")
-    get_state_manager().set("app", "state", "desktop")
+    state.set("app", "state", "desktop")
 
 
 def enable_firmware_updater_service():
@@ -114,9 +109,7 @@ def python_sdk_docs_url():
 
 
 def onboarding_completed():
-    return (
-        get_state_manager().get("app", "state", fallback="onboarding") != "onboarding"
-    )
+    return state.get("app", "state", fallback="onboarding") != "onboarding"
 
 
 def open_further():

--- a/pt_os_web_portal/backend/helpers/registration.py
+++ b/pt_os_web_portal/backend/helpers/registration.py
@@ -1,9 +1,10 @@
 from flask import current_app
 from pitop.common.logger import PTLogger
 
+from ... import state
+
 
 def set_registration_email(email):
     PTLogger.info(f"Function: set_registration_email(email='{email}')")
     with current_app.app_context():
-        state_manager = current_app.config["STATE_MANAGER"]
-        state_manager.set("registration", "email", email)
+        state.set("registration", "email", email)

--- a/pt_os_web_portal/device_registration/functions.py
+++ b/pt_os_web_portal/device_registration/functions.py
@@ -5,7 +5,7 @@ from time import sleep
 import requests
 from pitop.common.logger import PTLogger
 
-from ..state import StateManager
+from .. import state
 
 DEVICE_SERIALS_FILE = "/etc/pi-top/device_serial_numbers.json"
 DEVICE_INFO_FILE = "/etc/pi-top/pt-device-manager/device_version"
@@ -87,7 +87,7 @@ def get_os_version():
 
 def get_registration_data():
 
-    email_address = StateManager().get("registration", "email")
+    email_address = state.get("registration", "email")
     serial_number = get_serial_number()
     device_type = get_device_type()
     os_name, os_build_number, update_repo = get_os_version()
@@ -114,11 +114,11 @@ def send_data_and_get_resp(data):
 
 
 def device_is_registered():
-    return StateManager().get("registration", "is_registered") == "true"
+    return state.get("registration", "is_registered") == "true"
 
 
 def create_device_registered_breadcrumb():
-    StateManager().set("registration", "is_registered", "true")
+    state.set("registration", "is_registered", "true")
 
 
 def send_register_device_request():

--- a/pt_os_web_portal/device_registration/listener.py
+++ b/pt_os_web_portal/device_registration/listener.py
@@ -3,8 +3,8 @@ from time import sleep
 
 from pitop.common.logger import PTLogger
 
+from .. import state
 from ..event import AppEvents, subscribe
-from ..state import StateManager
 from .functions import device_is_registered, send_register_device_request
 
 
@@ -20,7 +20,7 @@ def register_device():
 def handle_is_connected_to_internet_event(is_connected):
     if (
         is_connected
-        and StateManager().get("app", "state", fallback="onboarding") != "onboarding"
+        and state.get("app", "state", fallback="onboarding") != "onboarding"
         and not device_is_registered()
     ):
         PTLogger.info(

--- a/pt_os_web_portal/os_updater/updater.py
+++ b/pt_os_web_portal/os_updater/updater.py
@@ -4,6 +4,7 @@ from threading import Thread
 from pitop.common.logger import PTLogger
 from pitop.common.sys_info import is_connected_to_internet
 
+from .. import state
 from ..event import AppEvents, post_event
 from .manager import OSUpdateManager
 from .message_handler import OSUpdaterFrontendMessageHandler
@@ -12,9 +13,8 @@ from .types import MessageType
 
 
 class OSUpdater:
-    def __init__(self, state_manager=None):
+    def __init__(self):
         self.manager = OSUpdateManager()
-        self.state_manager = state_manager
         self.message_handler = OSUpdaterFrontendMessageHandler()
 
     def start(self):
@@ -29,21 +29,18 @@ class OSUpdater:
     @property
     def last_checked_date(self):
         return datetime.strptime(
-            self.state_manager.get(
-                "os_updater", "last_checked_date", fallback="2000-01-01"
-            ),
+            state.get("os_updater", "last_checked_date", fallback="2000-01-01"),
             "%Y-%m-%d",
         ).date()
 
     def update_last_check_config(self) -> None:
-        self.state_manager.set(
+        state.set(
             "os_updater", "last_checked_date", f"{date.today().strftime('%Y-%m-%d')}"
         )
 
     def do_update_check(self, ws=None):
         should_check_for_updates = (
-            self.state_manager.get("app", "state", fallback="onboarding")
-            != "onboarding"
+            state.get("app", "state", fallback="onboarding") != "onboarding"
             and is_connected_to_internet()
             and self.last_checked_date != date.today()
         )
@@ -74,7 +71,7 @@ class OSUpdater:
         try:
             callback(MessageType.START, "Preparing OS upgrade", 0.0)
             self.manager.stage_upgrade(callback, packages)
-            self.state_manager.set(
+            state.set(
                 "os_updater",
                 "last_checked_date",
                 date.today().strftime("%Y-%m-%d"),

--- a/pt_os_web_portal/state.py
+++ b/pt_os_web_portal/state.py
@@ -1,46 +1,39 @@
 from configparser import ConfigParser
 from pathlib import Path
 
-from pitop.common.singleton import Singleton
+STATE_FILE_PATH = "/var/lib/pt-os-web-portal/state.cfg"
+config_parser = ConfigParser()
+
+path = Path(STATE_FILE_PATH)
+
+if not path.exists():
+    path.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+config_parser.read(STATE_FILE_PATH)
 
 
-class StateManager(metaclass=Singleton):
-    STATE_FILE_DIRECTORY = "/var/lib/pt-os-web-portal/"
-    STATE_FILE_NAME = "state.cfg"
-
-    def __init__(self):
-        Path(self.STATE_FILE_DIRECTORY).mkdir(parents=True, exist_ok=True)
-
-        path = Path(self.path_to_file)
-        if not path.exists():
-            path.touch()
-
-        self._config = ConfigParser()
-        self._config.read(self.path_to_file)
-
-    @property
-    def path_to_file(self):
-        return self.STATE_FILE_DIRECTORY + self.STATE_FILE_NAME
-
-    def get(self, section: str, key: str, fallback=None):
-        val = fallback
-        try:
-            val = self._config.get(section, key)
-        except Exception:
-            if fallback is None:
-                raise
-        finally:
-            return val
-
-    def set(self, section: str, key: str, value):
-        try:
-            if not self._config.has_section(section):
-                self._config.add_section(section)
-            self._config.set(section, key, value)
-            self.save()
-        except Exception:
+def get(section: str, key: str, fallback=None):
+    val = fallback
+    try:
+        val = config_parser.get(section, key)
+    except Exception:
+        if fallback is None:
             raise
+    finally:
+        return val
 
-    def save(self):
-        with open(self.path_to_file, "w") as configfile:
-            self._config.write(configfile)
+
+def set(section: str, key: str, value):
+    try:
+        if not config_parser.has_section(section):
+            config_parser.add_section(section)
+        config_parser.set(section, key, value)
+        save()
+    except Exception:
+        raise
+
+
+def save():
+    with open(STATE_FILE_PATH, "w") as configfile:
+        config_parser.write(configfile)


### PR DESCRIPTION
Closes #262 

Includes file locking to ensure that multiple threads do not perform state operations at the same time.

Discussion:
```
state.get("app", "state", fallback="onboarding") == "onboarding"
state.get("app", "onboarding", fallback="false") == "false"
```
"state" seems too generic for essentially only requiring a bool. we can have multiple bools before we need to start considering how we organise them.