### PR TITLE
Update copy in Upgrade Page

### DIFF
--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -8,12 +8,14 @@ import Spinner from "../../components/atoms/spinner/Spinner";
 import upgradePage from "../../assets/images/upgrade-page.png";
 import styles from "./UpgradePage.module.css";
 
-import { OSUpdaterMessage, OSUpdaterMessageType, UpdateMessageStatus } from "./UpgradePageContainer"
+import { ErrorType, OSUpdaterMessage, OSUpdaterMessageType, UpdateMessageStatus } from "./UpgradePageContainer"
 import NewOsVersionDialogContainer from "./newOsVersionDialog/NewOsVersionDialogContainer";
 import UpgradeHistoryTextArea from "../../components/upgradeHistoryTextArea/UpgradeHistoryTextArea";
 
 export enum ErrorMessage {
   GenericError = "There was a problem during system update. Please skip - you should be able to update later.",
+  NoSpaceAvailable = "There's not enough space on the device to install updates. Please, free up space and try updating again.",
+  AptError = "There was a problem during system update.",
 }
 
 export enum UpgradePageExplanation {
@@ -43,7 +45,7 @@ export type Props = {
   upgradeFinished: boolean,
   waitingForServer: boolean,
   downloadSize: number,
-  error: boolean,
+  error: ErrorType,
   requireBurn: boolean,
   shouldBurn: boolean,
   checkingWebPortal: boolean,
@@ -76,7 +78,20 @@ export default ({
     setIsNewOsDialogActive(requireBurn || shouldBurn);
   }, [requireBurn, shouldBurn]);
 
-  const errorMessage = error && ErrorMessage.GenericError;
+  const hasError = () => {
+    return error != ErrorType.None
+  }
+
+  const getErrorMessage = () =>{
+    switch (error) {
+      case ErrorType.NoSpaceAvailable:
+        return ErrorMessage.NoSpaceAvailable;
+      case ErrorType.AptError:
+        return ErrorMessage.AptError;
+      default:
+        return ErrorMessage.GenericError
+    }
+  }
 
   const parseMessage = (message: OSUpdaterMessage) => {
     if (message?.type === OSUpdaterMessageType.UpdateSources || message?.type === OSUpdaterMessageType.Upgrade || message?.type === OSUpdaterMessageType.PrepareUpgrade) {
@@ -152,24 +167,24 @@ export default ({
         nextButton={{
           onClick: upgradeIsRequired ? onStartUpgradeClick : onNextClick,
           label: continueButtonLabel,
-          disabled: !upgradeIsPrepared || upgradeIsRunning || waitingForServer || error
+          disabled: !upgradeIsPrepared || upgradeIsRunning || waitingForServer || hasError()
         }}
         skipButton={{ onClick: onSkipClick }}
-        showSkip={onSkipClick !== undefined && (isCompleted || error)}
+        showSkip={onSkipClick !== undefined && (isCompleted || hasError())}
         showBack={onBackClick !== undefined && !upgradeIsRunning}
         backButton={{
           onClick: onBackClick,
           disabled: upgradeIsRunning
         }}
       >
-        {errorMessage && <span className={styles.error}>{errorMessage}</span>}
+        {hasError() && <span className={styles.error}>{getErrorMessage()}</span>}
 
-      <NewOsVersionDialogContainer
-        active={isNewOsDialogActive}
-        requireBurn={requireBurn}
-        shouldBurn={shouldBurn}
-        onClose={() => setIsNewOsDialogActive(false)}
-      />
+        <NewOsVersionDialogContainer
+          active={isNewOsDialogActive}
+          requireBurn={requireBurn}
+          shouldBurn={shouldBurn}
+          onClose={() => setIsNewOsDialogActive(false)}
+        />
 
         { !waitingForServer && message && message?.type === OSUpdaterMessageType.Upgrade &&
           <UpgradeHistoryTextArea message={parseMessage(message)} />
@@ -179,7 +194,7 @@ export default ({
           <UpgradeHistoryTextArea message={parseMessage(message)} />
         }
 
-        { !error && waitingForServer && (
+        { !hasError() && waitingForServer && (
           <>
             <Spinner size={40} />{" "}
           </>

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -93,6 +93,13 @@ export default ({
     }
   }
 
+  const getPromptMessage = () => {
+    if (upgradeFinished) {
+      return <>Your system is <span className="green">up to date</span>!</>
+    }
+    return <>OK, I need to be <span className="green">updated</span></>
+  }
+
   const parseMessage = (message: OSUpdaterMessage) => {
     if (message?.type === OSUpdaterMessageType.UpdateSources || message?.type === OSUpdaterMessageType.Upgrade || message?.type === OSUpdaterMessageType.PrepareUpgrade) {
       let msg = JSON.stringify(message.payload?.message).trim().replace(/^"(.*)"$/, '$1')
@@ -158,11 +165,7 @@ export default ({
           src: upgradePage,
           alt: "upgrade-page-banner",
         }}
-        prompt={
-          <>
-            OK, I need to be <span className="green">updated</span>
-          </>
-        }
+        prompt={getPromptMessage()}
         explanation={getExplanation()}
         nextButton={{
           onClick: upgradeIsRequired ? onStartUpgradeClick : onNextClick,

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -79,7 +79,7 @@ export default ({
   }, [requireBurn, shouldBurn]);
 
   const hasError = () => {
-    return error != ErrorType.None
+    return error !== ErrorType.None
   }
 
   const getErrorMessage = () =>{

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -22,7 +22,7 @@ export enum UpgradePageExplanation {
   UpgradePreparedWithDownload = "{size} of new packages need to be installed. This might take {time} minutes.",
   UpgradePreparedWithoutDownload = "Some packages need to be installed. This might take a few minutes.",
   InProgress = "Please sit back and relax - this may take some time...",
-  Finish = "Great, system update has been successfully installed!\n\nPlease click the {continueButtonLabel} button to restart the application and {continueButtonAction}.",
+  Finish = "Great, system update has been successfully installed!\n\nPlease click the {continueButtonLabel} button to {continueButtonAction}.",
   WaitingForServer = "Please wait...",
   UpdatingSources = "We're checking to see if there are updates available",
   Preparing = "Preparing all packages to be updated...",

--- a/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
+++ b/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
@@ -89,7 +89,6 @@ describe("UpgradePageContainer", () => {
     defaultProps = {
       goToNextPage: jest.fn(),
       goToPreviousPage: jest.fn(),
-      onWebPortalUpgrade: jest.fn(),
       isCompleted: false,
     };
 

--- a/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
+++ b/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
@@ -377,12 +377,12 @@ describe("UpgradePageContainer", () => {
 
     it("renders the error message", async () => {
       const { getByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
     });
 
     it("renders the textarea component", async () => {
       const { getByText, findByTestId, queryByTestId } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await findByTestId("textarea");
       expect(queryByTestId("textarea")).toBeInTheDocument();
@@ -390,7 +390,7 @@ describe("UpgradePageContainer", () => {
 
     it("messages are displayed in the textarea component", async () => {
       const { getByText, findByTestId, queryByTestId } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await findByTestId("textarea");
       const textAreaElement = queryByTestId("textarea");
@@ -399,7 +399,7 @@ describe("UpgradePageContainer", () => {
 
     it("doesn't render the 'preparing updates' message", async () => {
       const { getByText, queryByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       expect(
         queryByText(UpgradePageExplanation.Preparing)
@@ -675,19 +675,19 @@ describe("UpgradePageContainer", () => {
 
     it("renders the error message", async () => {
       const { getByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
     });
 
     it("Skip button is present", async () => {
       const { getByText, queryByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       expect(queryByText("Skip")).toBeInTheDocument();
     });
 
     it("calls goToNextPage when Skip button clicked", async () => {
       const { getByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await waitForElement(() => getByText("Skip"));
       fireEvent.click(getByText("Skip"));
@@ -697,14 +697,14 @@ describe("UpgradePageContainer", () => {
 
     it("Update button is present", async () => {
       const { getByText, queryByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       expect(queryByText("Update")).toBeInTheDocument();
     });
 
     it("Update button is disabled", async () => {
       const { getByText } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await waitForElement(() => getByText("Update"));
       expect(getByText("Update")).toHaveProperty("disabled", true);
@@ -712,7 +712,7 @@ describe("UpgradePageContainer", () => {
 
     it("renders the textarea component", async () => {
       const { getByText, queryByTestId } = mount();
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       expect(queryByTestId("textarea")).toBeInTheDocument();
     });
@@ -860,7 +860,7 @@ describe("UpgradePageContainer", () => {
       await waitForPreparation();
       fireEvent.click(getByText("Update"));
 
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
     });
 
     it("doesn't render the 'is upgrading' message", async () => {
@@ -897,7 +897,7 @@ describe("UpgradePageContainer", () => {
       await waitForPreparation();
       fireEvent.click(getByText("Update"));
 
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
       expect(getByText("Back")).toHaveProperty("disabled", false);
     });
 
@@ -905,7 +905,7 @@ describe("UpgradePageContainer", () => {
       const { getByText, waitForPreparation } = mount();
       await waitForPreparation();
       fireEvent.click(getByText("Update"));
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await waitForElement(() => getByText("Skip"));
       expect(getByText("Skip")).toHaveProperty("disabled", false);
@@ -915,7 +915,7 @@ describe("UpgradePageContainer", () => {
       const { getByText, waitForPreparation } = mount();
       await waitForPreparation();
       fireEvent.click(getByText("Update"));
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await waitForElement(() => getByText("Skip"));
       fireEvent.click(getByText("Skip"));
@@ -927,7 +927,7 @@ describe("UpgradePageContainer", () => {
       const { getByText, waitForPreparation } = mount();
       await waitForPreparation();
       fireEvent.click(getByText("Update"));
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.AptError));
 
       await waitForElement(() => getByText("Update"));
       expect(getByText("Update")).toHaveProperty("disabled", true);
@@ -1110,7 +1110,7 @@ describe("UpgradePageContainer", () => {
     it("renders the error message", async () => {
       const { getByText } = mount();
 
-      await waitForElement(() => getByText(ErrorMessage.GenericError));
+      await waitForElement(() => getByText(ErrorMessage.NoSpaceAvailable));
     });
 
     it("Skip button exists", async () => {

--- a/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
+++ b/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
@@ -193,6 +193,14 @@ describe("UpgradePageContainer", () => {
       });
     });
 
+    it("renders prompt correctly", async () => {
+      const { getByText, container: upgradePage } = mount();
+      await waitForElement(() => getByText(UpgradePageExplanation.UpdatingSources))
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
+    });
+
     it("renders the 'updating sources' message", async () => {
       const { getByText } = mount();
       await waitForElement(() => getByText(UpgradePageExplanation.UpdatingSources));
@@ -278,6 +286,15 @@ describe("UpgradePageContainer", () => {
           });
         });
       });
+
+      it("renders prompt correctly", async () => {
+        const { getByText, container: upgradePage } = mount();
+        await waitForElement(() => getByText(UpgradePageExplanation.UpdatingWebPortal))
+
+        const prompt = upgradePage.querySelector(".prompt");
+        expect(prompt).toMatchSnapshot();
+      });
+
       it("renders the 'preparing your system to be updated' message", async () => {
         const { getByText } = mount();
         await waitForElement(() => getByText(UpgradePageExplanation.UpdatingWebPortal))
@@ -374,6 +391,14 @@ describe("UpgradePageContainer", () => {
       });
     });
 
+    it("renders prompt correctly", async () => {
+      const { getByText, container: upgradePage } = mount();
+      await waitForElement(() => getByText(ErrorMessage.AptError))
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
+    });
+
     it("renders the error message", async () => {
       const { getByText } = mount();
       await waitForElement(() => getByText(ErrorMessage.AptError));
@@ -458,6 +483,14 @@ describe("UpgradePageContainer", () => {
       });
     });
 
+    it("renders prompt correctly", async () => {
+      const { getByText, container: upgradePage } = mount();
+      await waitForElement(() => getByText(UpgradePageExplanation.UpdatingWebPortal))
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
+    });
+
     it("renders the updating web-portal message", async () => {
       const { getByText } = mount();
       await waitForElement(() => getByText(UpgradePageExplanation.UpdatingWebPortal))
@@ -540,6 +573,14 @@ describe("UpgradePageContainer", () => {
       restartWebPortalServiceMock.mockRestore();
       serverStatusMock.mockRestore();
     })
+
+    it("renders prompt correctly", async () => {
+      const { getByText, container: upgradePage } = mount();
+      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
+    });
 
     it("renders the 'please wait' message while restarting web-portal service", async () => {
       const { getByText } = mount();
@@ -672,6 +713,14 @@ describe("UpgradePageContainer", () => {
       });
     });
 
+    it("renders prompt correctly", async () => {
+      const { getByText, container: upgradePage } = mount();
+      await waitForElement(() => getByText(ErrorMessage.AptError));
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
+    });
+
     it("renders the error message", async () => {
       const { getByText } = mount();
       await waitForElement(() => getByText(ErrorMessage.AptError));
@@ -753,6 +802,15 @@ describe("UpgradePageContainer", () => {
           }
         });
       });
+    });
+
+    it("renders prompt correctly", async () => {
+      const { getByText, waitForPreparation, container: upgradePage } = mount();
+      await waitForPreparation();
+      fireEvent.click(getByText("Update"));
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
     });
 
     it("renders the 'upgrade is in progress' message", async () => {
@@ -852,6 +910,17 @@ describe("UpgradePageContainer", () => {
           }
         });
       });
+    });
+
+    it("renders prompt correctly", async () => {
+      const { container: upgradePage, getByText, waitForPreparation } = mount();
+      await waitForPreparation();
+      fireEvent.click(getByText("Update"));
+
+      await waitForElement(() => getByText(ErrorMessage.AptError));
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
     });
 
     it("renders the error message", async () => {
@@ -973,6 +1042,16 @@ describe("UpgradePageContainer", () => {
       restartWebPortalServiceMock.mockRestore();
       serverStatusMock.mockRestore();
       act(() => server.close());
+    });
+
+    it("renders prompt correctly", async () => {
+      const { container: upgradePage, getByText, waitForPreparation, waitForUpgradeFinish } = mount();
+      await waitForPreparation();
+      fireEvent.click(getByText("Update"));
+      await waitForUpgradeFinish();
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
     });
 
     it("renders the upgrade finished message", async () => {
@@ -1104,6 +1183,14 @@ describe("UpgradePageContainer", () => {
           }
         });
       });
+    });
+
+    it("renders prompt correctly", async () => {
+      const { getByText, container: upgradePage } = mount();
+      await waitForElement(() => getByText(ErrorMessage.NoSpaceAvailable));
+
+      const prompt = upgradePage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
     });
 
     it("renders the error message", async () => {

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -23,6 +23,19 @@ exports[`UpgradePageContainer renders the correct banner image 1`] = `
 />
 `;
 
+exports[`UpgradePageContainer when sources are updated and there are updates to the web-portal package renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
+`;
+
 exports[`UpgradePageContainer when sources are updated and there are updates to the web-portal package textarea component displays web-portal upgrade messages 1`] = `
 <textarea
   class="textarea"
@@ -78,6 +91,19 @@ exports[`UpgradePageContainer when the system is being updated renders progress 
 </div>
 `;
 
+exports[`UpgradePageContainer when the system is being updated renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
+`;
+
 exports[`UpgradePageContainer when the system upgrade fails messages are displayed in the textarea component 1`] = `
 <textarea
   class="textarea"
@@ -89,6 +115,19 @@ dpkg-exec: Running dpkg
 
 There was an error while upgrading packages.
 </textarea>
+`;
+
+exports[`UpgradePageContainer when the system upgrade fails renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
 `;
 
 exports[`UpgradePageContainer when the upgrade finishes messages are displayed in the textarea component 1`] = `
@@ -134,6 +173,20 @@ exports[`UpgradePageContainer when the upgrade finishes renders progress bar cor
     />
   </svg>
 </div>
+`;
+
+exports[`UpgradePageContainer when the upgrade finishes renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  Your system is 
+  <span
+    class="green"
+  >
+    up to date
+  </span>
+  !
+</h1>
 `;
 
 exports[`UpgradePageContainer when there are major OS updates available and user 'requireBurn' renders the correct message 1`] = `
@@ -274,6 +327,19 @@ exports[`UpgradePageContainer when there are major OS updates available and user
 </div>
 `;
 
+exports[`UpgradePageContainer when there's not enough space left on device renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
+`;
+
 exports[`UpgradePageContainer when updating sources fails messages are displayed in the textarea component 1`] = `
 <textarea
   class="textarea"
@@ -285,6 +351,45 @@ Updating blah
 
 There was a problem updating sources
 </textarea>
+`;
+
+exports[`UpgradePageContainer when updating sources fails renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
+`;
+
+exports[`UpgradePageContainer when updating web-portal fails renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
+`;
+
+exports[`UpgradePageContainer when updating web-portal succeeds renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
 `;
 
 exports[`UpgradePageContainer while updating sources messages are displayed in the textarea component 1`] = `
@@ -329,6 +434,32 @@ exports[`UpgradePageContainer while updating sources renders progress bar correc
     />
   </svg>
 </div>
+`;
+
+exports[`UpgradePageContainer while updating sources renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
+`;
+
+exports[`UpgradePageContainer while updating web-portal renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  OK, I need to be 
+  <span
+    class="green"
+  >
+    updated
+  </span>
+</h1>
 `;
 
 exports[`UpgradePageContainer while updating web-portal textarea component displays web-portal upgrade messages 1`] = `


### PR DESCRIPTION
- Add more descriptive error messages
- Page "title" changes after a successful update (“OK, I need to be updated” => "Great, your system is up to date")
- Service doesn’t restart anymore when the update finishes