### PR TITLE
Avoid displaying 'no SD card' animation on first reboot

### DIFF
--- a/frontend/src/pages/restartPage/RestartPageContainer.tsx
+++ b/frontend/src/pages/restartPage/RestartPageContainer.tsx
@@ -9,6 +9,7 @@ import enableFirmwareUpdaterService from "../../services/enableFirmwareUpdaterSe
 import enableFurtherLinkService from "../../services/enableFurtherLinkService";
 import stopOnboardingAutostart from "../../services/stopOnboardingAutostart";
 import reboot from "../../services/reboot";
+import setHubToMode5 from "../../services/setHubToMode5";
 import restoreFiles from "../../services/restoreFiles";
 import serverStatus from "../../services/serverStatus"
 import updateEeprom from "../../services/updateEeprom"
@@ -174,6 +175,12 @@ export default ({
             safelyRunService(
               enablePtMiniscreen,
               "Reminded myself to tell the miniscreen to do its thing in the morning..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              setHubToMode5,
+              "Made sure that the miniscreen doesn't go to sleep while I reboot..."
             )
           )
           .catch(console.error)

--- a/frontend/src/pages/restartPage/__tests__/RestartPageContainer.test.tsx
+++ b/frontend/src/pages/restartPage/__tests__/RestartPageContainer.test.tsx
@@ -26,6 +26,8 @@ import serverStatus from "../../../services/serverStatus";
 import updateEeprom from "../../../services/updateEeprom";
 import enablePtMiniscreen from "../../../services/enablePtMiniscreen";
 import updateHubFirmware from "../../../services/updateHubFirmware";
+import setHubToMode5 from "../../../services/setHubToMode5";
+
 
 import { act } from "react-dom/test-utils";
 
@@ -40,6 +42,7 @@ jest.mock("../../../services/serverStatus");
 jest.mock("../../../services/updateEeprom");
 jest.mock("../../../services/enablePtMiniscreen");
 jest.mock("../../../services/updateHubFirmware");
+jest.mock("../../../services/setHubToMode5");
 
 
 const configureLandingMock = configureLanding as jest.Mock;
@@ -53,6 +56,7 @@ const serverStatusMock = serverStatus as jest.Mock;
 const updateEepromMock = updateEeprom as jest.Mock;
 const enablePtMiniscreenMock = enablePtMiniscreen as jest.Mock;
 const updateHubFirmwareMock = updateHubFirmware as jest.Mock;
+const setHubToMode5Mock = updateHubFirmware as jest.Mock;
 
 
 const mockServices = [
@@ -66,6 +70,7 @@ const mockServices = [
   updateHubFirmwareMock,
   rebootMock,
   enablePtMiniscreenMock,
+  setHubToMode5,
 ];
 
 
@@ -271,6 +276,22 @@ describe("RestartPageContainer", () => {
     describe('when update hub firmware fails', () => {
       beforeEach(() => {
         updateHubFirmwareMock.mockRejectedValue(new Error());
+      });
+
+      it('calls remaining services', async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        mockServices.forEach((mock) => {
+          expect(mock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when setting hub mode fails', () => {
+      beforeEach(() => {
+        setHubToMode5.mockRejectedValue(new Error());
       });
 
       it('calls remaining services', async () => {

--- a/frontend/src/services/setHubToMode5.ts
+++ b/frontend/src/services/setHubToMode5.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+import apiBaseUrl from "./apiBaseUrl";
+
+export default async function setHubToMode5() {
+  await axios.post(
+    `${apiBaseUrl}/set-hub-mode-5`,
+    {}
+  );
+}

--- a/pt_os_web_portal/backend/routes.py
+++ b/pt_os_web_portal/backend/routes.py
@@ -28,6 +28,7 @@ from .helpers.finalise import (
     onboarding_completed,
     reboot,
     restore_files,
+    set_hub_to_mode_5,
     stop_onboarding_autostart,
     update_eeprom,
 )
@@ -354,6 +355,13 @@ def post_enable_firmware_updater_service():
 def post_enable_further_link_service():
     logger.debug("Route '/enable-further-link-service'")
     enable_further_link_service()
+    return "OK"
+
+
+@app.route("/set-hub-mode-5", methods=["POST"])
+def post_set_hub_to_mode_5():
+    logger.debug("Route '/set-hub-mode-5'")
+    set_hub_to_mode_5()
     return "OK"
 
 


### PR DESCRIPTION
Ticket: https://pi-top.atlassian.net/browse/OS-1192

Reboot after the onboarding finishes may take a few minutes. This can cause a 'no SD card' icon to appear in the miniscreen of a pi-top [4].

To fix this issue, this PR sets the hub into mode 5 before rebooting. This means that the hub's MCU takes control of the OLED from the pi-top [4] and displays the rotating 4 animation in the screen. The hub will stay in this mode until the system is powered off or reboots. 

One thing to consider before this goes in is that when mode 5 is set, the hub starts a timer to shutdown the pi-top after `PWR__M1_TIMEOUT_MAX` seconds. This is a register that defaults to 300secs, which should be enough for the device to reboot. We could increase this timeout, to some other value for this first reboot if we think it's necessary.