### PR TITLE
feat: confirm users want to leave during restart

### DIFF
--- a/frontend/src/pages/restartPage/RestartPageContainer.tsx
+++ b/frontend/src/pages/restartPage/RestartPageContainer.tsx
@@ -57,6 +57,23 @@ export default ({
       .catch(() => setLegacyHubFirmware(false))
   }, [])
 
+  // stop users leaving page when setting up or waiting for reboot to finish.
+  useEffect(() => {
+    if (!(isSettingUpDevice || isWaitingForServer)) {
+      return;
+    }
+
+    function beforeUnloadListener(event: BeforeUnloadEvent) {
+      // prevent leaving page without confirmation
+      event.preventDefault();
+      event.returnValue = true // chrome requires return value to be set
+    }
+
+    window.addEventListener("beforeunload", beforeUnloadListener);
+    return () =>
+      window.removeEventListener("beforeunload", beforeUnloadListener);
+  }, [isSettingUpDevice, isWaitingForServer]);
+
   function safelyRunService(service: () => Promise<void>, message: string) {
     return service()
       .then(() => setProgressMessage(message))

--- a/frontend/src/pages/restartPage/__tests__/RestartPageContainer.test.tsx
+++ b/frontend/src/pages/restartPage/__tests__/RestartPageContainer.test.tsx
@@ -95,6 +95,19 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+const userMustConfirmBeforeLeaving = () => {
+  // dispatch beforeunload event to simulate beginning of unload process
+  const event = new Event('beforeunload')
+  const preventDefaultSpy = jest.spyOn(event, "preventDefault");
+  window.dispatchEvent(event);
+
+  // calling preventDefault causes most browsers to confirm leaving with user
+  // event.returnValue needs to be set for chrome
+  return (
+    preventDefaultSpy.mock.calls.length > 0 &&
+    event.returnValue
+  );
+};
 
 describe("RestartPageContainer", () => {
   let defaultProps: Props;
@@ -129,6 +142,10 @@ describe("RestartPageContainer", () => {
     expect(
       restartPageContainer.querySelector(".error")
     ).not.toBeInTheDocument();
+  });
+
+  it("does not ask user for confirmation before they leave the page", async () => {
+    expect(userMustConfirmBeforeLeaving()).toBeFalsy();
   });
 
   describe("when globalError is true", () => {
@@ -190,6 +207,16 @@ describe("RestartPageContainer", () => {
       fireEvent.click(getByText("Restart"));
 
       expect(queryByText("Restart")).toBeDisabled();
+
+      await wait();
+    });
+
+    it("asks user for confirmation before they leave the page", async () => {
+      fireEvent.click(getByText("Restart"));
+
+      await wait();
+
+      expect(userMustConfirmBeforeLeaving()).toBeTruthy();
 
       await wait();
     });
@@ -343,6 +370,16 @@ describe("RestartPageContainer", () => {
         expect(querySpinner(restartPageContainer)).toBeInTheDocument();
       });
 
+      it("asks user for confirmation before they leave the page", async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        expect(userMustConfirmBeforeLeaving()).toBeTruthy();
+
+        await wait();
+      });
+
       describe('when the device is back online', () => {
         it('updates the displayed message', async () => {
           await act(async () => {
@@ -360,6 +397,15 @@ describe("RestartPageContainer", () => {
             await Promise.resolve();
           });
           expect(querySpinner(restartPageContainer)).not.toBeInTheDocument();
+        });
+
+        it("does not ask user for confirmation before they leave the page", async () => {
+          await act(async () => {
+            jest.runOnlyPendingTimers();
+            jest.runOnlyPendingTimers();
+            await Promise.resolve();
+          });
+          expect(userMustConfirmBeforeLeaving()).toBeFalsy();
         });
       });
     });


### PR DESCRIPTION
Closes: https://pi-top.atlassian.net/browse/OS-1147

When setting up the pi-top or waiting for the reboot to complete it is
potentially destructive or confusing to reload or close the browser tab.

Intercept the 'beforeunload' event and prevent the unload while either
of the above are happening.

Defining a custom message for the confirmation dialog is no longer
possible with modern browsers: https://stackoverflow.com/a/50132210/5533971