### PR TITLE
Specify 'markupsafe' & 'jinja2' versions for python tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ Flask>=1.1.2,<1.2
 Flask-Cors>=3.0.9,<3.1
 Flask-Sockets>=0.2.1<0.3
 requests>=2.25.1,<2.26.0
+markupsafe==2.0.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,5 @@ Flask>=1.1.2,<1.2
 Flask-Cors>=3.0.9,<3.1
 Flask-Sockets>=0.2.1<0.3
 requests>=2.25.1,<2.26.0
-markupsafe==2.0.1
+jinja2>=2.11.3,<3.0.0
+markupsafe>=1.1.1,<2.0.0


### PR DESCRIPTION
python test runs have been failing for the last few days:
```
Traceback:
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_wifi_manager.py:1: in <module>
    from flask import json
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/flask/__init__.py:14: in <module>
    from jinja2 import escape
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/__init__.py:12: in <module>
    from .environment import Environment
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/environment.py:[25](https://github.com/pi-top/pi-topOS-Web-Portal/runs/5321855517?check_suite_focus=true#step:5:25): in <module>
    from .defaults import BLOCK_END_STRING
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/defaults.py:3: in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/filters.py:13: in <module>
    from markupsafe import soft_unicode
E   ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/markupsafe/__init__.py)
```

this is because `markupsafe` introduced a breaking change in https://github.com/pallets/markupsafe/pull/261 and at the same time `jinja2` doesn't provide an upper version limit of their dependency as per https://github.com/pallets/jinja/issues/1585 .

This PR specifies the required version of these packages to run the python tests... These versions will closely match the version of these packages available in debian (as `python3-jinja2` & `python3-markupsafe`)

