### PR TITLE
Display correct IP address on miniscreen onboarding app

### DIFF
--- a/pt_os_web_portal/miniscreen_onboarding_assistant/pages/guide.py
+++ b/pt_os_web_portal/miniscreen_onboarding_assistant/pages/guide.py
@@ -1,15 +1,10 @@
 from enum import Enum, auto
-from ipaddress import ip_address
 from os import path
 from pathlib import Path
 from subprocess import run
 
 from PIL import Image
-from pitop.common.sys_info import (
-    InterfaceNetworkData,
-    get_address_for_ptusb_connected_device,
-    get_internal_ip,
-)
+from pitop.common.sys_info import get_pi_top_ip
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
 from ...event import AppEvents, subscribe
@@ -178,23 +173,6 @@ class OpenBrowserPage(GuidePageBase):
 
     @property
     def text(self):
-        def get_pi_top_ip():
-            for iface in ("wlan0", "eth0"):
-                try:
-                    ip = ip_address(get_internal_ip(iface))
-                    return ip.exploded
-                except ValueError:
-                    pass
-
-            # ptusb0 always has an IP address; check is performed differently
-            try:
-                if len(get_address_for_ptusb_connected_device()) > 0:
-                    return InterfaceNetworkData("ptusb0").ip.exploded
-            except Exception:
-                pass
-
-            return "192.168.90.1"
-
         hostname = run("hostname", encoding="utf-8", capture_output=True)
         hostname = hostname.stdout.strip()
         ip = get_pi_top_ip()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1275) |


#### Main changes
- Replace the static IP 192.168.64.1 in the onboarding miniscreen guide with the actual IP of the pi-top. It will first check the Wi-Fi and ethernet interfaces; if the pi-top doesn't have an IP address in those interfaces, it will then look for an IP in the USB interface; if no IP is found, it will then return the AP IP address.
- Removed the `http://` prefix since the text wouldn't fit on screen in some cases...

This PR makes use of a new SDK helper introduced in https://github.com/pi-top/pi-top-Python-SDK/pull/521

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
- Install this PR artifacts
- Install https://github.com/pi-top/pi-top-Python-SDK/pull/521 artifacts
- Update state to tell web-portal that the device is not onboarded: `sudo sed -i "s|onboarded = true|onboarded = false|g" /var/lib/pt-os-web-portal/state.cfg`
- Restart web-portal service: `sudo systemctl restart pt-os-web-portal`
- By this point,  you might want to disconnect your pi-top from WiFi before testing so that IP isn't displayed in the miniscreen onboarding app.
- The miniscreen onboarding app should start. Verify the changes to the IP displayed in the guide using USB or AP mode.

After testing, restore onboarding state and restart web-portal service:
```
sudo sed -i "s|onboarded = false|onboarded = true|g" /var/lib/pt-os-web-portal/state.cfg
sudo systemctl restart pt-os-web-portal
```

#### Tag anyone who definitely needs to review or help
-
