### PR TITLE
fix: standalone upgrade skip text in web-renderer

### DIFF
--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -9,6 +9,7 @@ import AboutPageContainer from "./pages/aboutPage/AboutPageContainer";
 import UpgradePageContainer from "./pages/upgradePage/UpgradePageContainer";
 import closeOsUpdaterWindow from "./services/closeOsUpdaterWindow";
 import LandingPage from "./pages/landingPage/LandingPage";
+import { runningOnWebRenderer } from "./helpers/utils";
 
 export default () => (
   <ErrorBoundary
@@ -26,9 +27,9 @@ export default () => (
         path="/updater"
         render={() => (
           <UpgradePageContainer
-            goToNextPage={() => {
-              closeOsUpdaterWindow();
-            }}
+            goToNextPage={closeOsUpdaterWindow}
+            skipButtonLabel="Close"
+            hideSkip={!runningOnWebRenderer()}
           />
         )}
       />

--- a/frontend/src/components/atoms/button/Button.module.css
+++ b/frontend/src/components/atoms/button/Button.module.css
@@ -40,3 +40,7 @@
   border: none;
   padding: 0;
 }
+
+.hidden {
+  visibility: hidden !important;
+}

--- a/frontend/src/components/atoms/button/Button.tsx
+++ b/frontend/src/components/atoms/button/Button.tsx
@@ -10,6 +10,7 @@ export type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   className?: string;
   type?: 'button'|'reset'|'submit';
   unstyled?: boolean;
+  hidden?: boolean;
 };
 
 export default ({
@@ -19,10 +20,15 @@ export default ({
   disabled = false,
   type = 'button',
   unstyled = false,
+  hidden,
   ...props
 }: Props) => (
   <button
-    className={cx(unstyled ? styles.unstyled : styles.styled, className)}
+    className={cx(className, {
+      [styles.unstyled]: unstyled,
+      [styles.styled]: !unstyled,
+      [styles.hidden]: hidden,
+    })}
     disabled={disabled}
     onClick={onClick}
     type={type}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -73,7 +73,7 @@ export default ({
         <div className={styles.backButtonContainer}>
           {backButton && showBack && (
             <Button {...backButton} className={styles.backButton} unstyled>
-              Back
+              {backButton.label ? backButton.label : "Back"}
             </Button>
           )}
         </div>
@@ -89,7 +89,7 @@ export default ({
         <div className={styles.skipButtonContainer}>
           {skipButton && showSkip && (
             <Button {...skipButton} className={styles.skipButton} unstyled>
-              Skip
+              {skipButton.label ? skipButton.label : "Skip"}
             </Button>
           )}
         </div>

--- a/frontend/src/pages/aboutPage/__tests__/AboutPageContainer.test.tsx
+++ b/frontend/src/pages/aboutPage/__tests__/AboutPageContainer.test.tsx
@@ -65,7 +65,7 @@ describe("AboutPageContainer", () => {
   it("Next button is hidden", async () => {
     const { getByText } = mount();
 
-    expect(getByText("Next").parentElement).toHaveProperty("hidden", true);
+    expect(getByText("Next").parentElement).toHaveClass("hidden");
 
     await wait();
   });

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -38,6 +38,7 @@ export type Props = {
   onNextClick?: () => void;
   onSkipClick?: () => void;
   onBackClick?: () => void;
+  skipButtonLabel?: string;
   onStartUpgradeClick: () => void;
   onRetry: (defaultBackend: boolean) => void;
   isCompleted?: boolean;
@@ -46,6 +47,7 @@ export type Props = {
   downloadSize: number,
   error: ErrorType,
   requireBurn: boolean,
+  hideSkip?: boolean,
   shouldBurn: boolean,
 };
 
@@ -53,6 +55,7 @@ export default ({
   onSkipClick,
   onBackClick,
   onNextClick,
+  skipButtonLabel,
   onStartUpgradeClick,
   onRetry,
   updateState,
@@ -61,6 +64,7 @@ export default ({
   downloadSize,
   requireBurn,
   shouldBurn,
+  hideSkip,
   error,
 }: Props) => {
   const [isNewOsDialogActive, setIsNewOsDialogActive] = useState(false);
@@ -179,8 +183,8 @@ export default ({
           disabled: !hasError() && nextButtonDisabledStates.includes(updateState),
           hidden: error === ErrorType.UpdaterAlreadyRunning || (updateState === UpdateState.Finished && runsUpdaterStandaloneAppInBrowser)
         }}
-        skipButton={{ onClick: onSkipClick }}
-        showSkip={onSkipClick !== undefined && (hasError() || isCompleted === true)}
+        skipButton={{ onClick: onSkipClick, label: skipButtonLabel }}
+        showSkip={!hideSkip && onSkipClick !== undefined && (hasError() || isCompleted === true)}
         showBack={onBackClick !== undefined && (hasError() || showBackButtonStates.includes(updateState))}
         backButton={{
           onClick: onBackClick,

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -99,10 +99,12 @@ export type OSUpdaterMessage = UpgradeMessage | SizeMessage | StateMessage;
 export type Props = {
   goToNextPage?: () => void;
   goToPreviousPage?: () => void;
+  hideSkip?: boolean;
+  skipButtonLabel?: string;
   isCompleted?: boolean;
 };
 
-export default ({ goToNextPage, goToPreviousPage, isCompleted }: Props) => {
+export default ({ goToNextPage, goToPreviousPage, hideSkip, skipButtonLabel, isCompleted }: Props) => {
   const [message, setMessage] = useState<OSUpdaterMessage>();
   const [isOpen, setIsOpen] = useState(false);
   document.title = "pi-topOS System Update"
@@ -342,6 +344,8 @@ export default ({ goToNextPage, goToPreviousPage, isCompleted }: Props) => {
       onNextClick={goToNextPage}
       onSkipClick={goToNextPage}
       onBackClick={goToPreviousPage}
+      hideSkip={hideSkip}
+      skipButtonLabel={skipButtonLabel}
       onStartUpgradeClick={() => {
         if (isOpen) {
           setState(UpdateState.UpgradingSystem);

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`UpgradePageContainer when there are major OS updates available and user
       >
         For more information, go to 
         <button
-          class="unstyled link"
+          class="link unstyled"
           type="button"
         >
           https://pi-top.com/help/out-of-date
@@ -246,7 +246,7 @@ exports[`UpgradePageContainer when there are major OS updates available and user
         class="actions"
       >
         <button
-          class="unstyled btn"
+          class="btn unstyled"
           type="button"
         >
           <svg
@@ -501,7 +501,7 @@ exports[`UpgradePageContainer when there are major OS updates available and user
       >
         For more information, go to 
         <button
-          class="unstyled link"
+          class="link unstyled"
           type="button"
         >
           https://pi-top.com/help/out-of-date
@@ -518,7 +518,7 @@ exports[`UpgradePageContainer when there are major OS updates available and user
         class="actions"
       >
         <button
-          class="unstyled btn"
+          class="btn unstyled"
           type="button"
         >
           <svg


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [OS-1264](https://pi-top.atlassian.net/browse/OS-1264) |


#### Main changes
- The standalone upgrade page's skip button text is be "Done" when viewed in web-renderer
- The Button component should hide regardless of other css applied to it
when "hidden" prop is true.
- Override default UpgradePage showSkipButton logic if hideSkip is true
- Use hideSkip prop to override default showSkipButton logic when
running in standalone on a browser.

#### Other notes

It turns out some of the other points in the ticket were largely already done. The code in this area is complex and I really had to dig into it to understand how they were achieved. We should review the flow and/or refactor the existing code before making any further changes.