### PR TITLE
feat: add standalone wifi page

### DIFF
--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter, Route } from "react-router-dom";
+import { BrowserRouter, Route, Switch } from "react-router-dom";
 
 import ErrorBoundary from "./components/errorBoundary/ErrorBoundary";
 import OnboardingApp from "./components/onboarding_app/App";
@@ -22,20 +22,22 @@ export default () => (
     }
   >
     <BrowserRouter>
-      <Route exact path="/landing" component={LandingPage} />
-      <Route path="/onboarding" component={OnboardingApp} />
-      <Route path="/about" component={AboutPageContainer} />
-      <Route path="/wifi" component={StandaloneWifiPageContainer} />
-      <Route
-        path="/updater"
-        render={() => (
-          <UpgradePageContainer
-            goToNextPage={closeOsUpdaterWindow}
-            skipButtonLabel="Close"
-            hideSkip={!runningOnWebRenderer()}
-          />
-        )}
-      />
+      <Switch>
+        <Route path="/onboarding" component={OnboardingApp} />
+        <Route path="/about" component={AboutPageContainer} />
+        <Route path="/wifi" component={StandaloneWifiPageContainer} />
+        <Route
+          path="/updater"
+          render={() => (
+            <UpgradePageContainer
+              goToNextPage={closeOsUpdaterWindow}
+              skipButtonLabel="Close"
+              hideSkip={!runningOnWebRenderer()}
+            />
+          )}
+        />
+        <Route component={LandingPage} />
+      </Switch>
     </BrowserRouter>
   </ErrorBoundary>
 );

--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -9,6 +9,8 @@ import AboutPageContainer from "./pages/aboutPage/AboutPageContainer";
 import UpgradePageContainer from "./pages/upgradePage/UpgradePageContainer";
 import closeOsUpdaterWindow from "./services/closeOsUpdaterWindow";
 import LandingPage from "./pages/landingPage/LandingPage";
+import StandaloneWifiPageContainer from "./pages/wifiPage/StandaloneWifiPageContainer";
+
 import { runningOnWebRenderer } from "./helpers/utils";
 
 export default () => (
@@ -23,6 +25,7 @@ export default () => (
       <Route exact path="/landing" component={LandingPage} />
       <Route path="/onboarding" component={OnboardingApp} />
       <Route path="/about" component={AboutPageContainer} />
+      <Route path="/wifi" component={StandaloneWifiPageContainer} />
       <Route
         path="/updater"
         render={() => (

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -23,6 +23,7 @@ export type Props = {
   skipButton?: LayoutButtonProps;
   backButton?: LayoutButtonProps;
   showSkip?: boolean;
+  showNext?: boolean;
   showBack?: boolean;
   showHeader?: boolean;
   explanation?: string;
@@ -37,6 +38,7 @@ export default ({
   skipButton,
   backButton,
   showHeader = true,
+  showNext = true,
   showSkip = true,
   showBack = true,
   explanation,
@@ -81,7 +83,7 @@ export default ({
         {isLoading ? (
           <Spinner size={60} />
         ) : (
-          <PrimaryButton {...nextButton}>
+          showNext && <PrimaryButton {...nextButton}>
             {nextButton.label ? nextButton.label : "Next"}
           </PrimaryButton>
         )}

--- a/frontend/src/hooks/usePrevious.tsx
+++ b/frontend/src/hooks/usePrevious.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useRef, useEffect } from "react";
 
-export default function usePrevious(value: any) {
-    const ref = useRef();
+export default function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
 
-    useEffect(() => {
-      ref.current = value;
-    });
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
 
-    return ref.current;
-  }
+  return ref.current;
+}

--- a/frontend/src/pages/wifiPage/StandaloneWifiPageContainer.tsx
+++ b/frontend/src/pages/wifiPage/StandaloneWifiPageContainer.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from "react";
+
+import WifiPage from "./WifiPage";
+import { Network } from "../../types/Network";
+import closeWifiWindow from "../../services/closeWifiWindow";
+import { runningOnWebRenderer } from "../../helpers/utils";
+import getNetworks from "../../services/getNetworks";
+import connectedBSSID from "../../services/connectedBSSID";
+
+export default () => {
+  const [connectedNetwork, setConnectedNetwork] = useState<Network>();
+  const [isFetchingNetworks, setIsFetchingNetworks] = useState(false);
+  const [fetchNetworksError, setFetchNetworksError] = useState(false);
+  const [networks, setNetworks] = useState<Network[]>([]);
+
+  const fetchNetworks = () => {
+    setIsFetchingNetworks(true);
+    setFetchNetworksError(false);
+
+    Promise.all([getNetworks(), connectedBSSID()])
+      .then(([getNetworksResponse, connectedBSSIDResponse]) => {
+        setNetworks(getNetworksResponse);
+
+        const currentConnectedNetwork = getNetworksResponse.find(
+          (network) => network.bssid === connectedBSSIDResponse
+        );
+        if (currentConnectedNetwork) {
+          setConnectedNetwork(currentConnectedNetwork);
+        }
+      })
+      .catch(() => setFetchNetworksError(true))
+      .finally(() => setIsFetchingNetworks(false));
+  };
+
+  useEffect(() => {
+    fetchNetworks();
+  }, []);
+
+  return (
+    <WifiPage
+      onRefreshClick={fetchNetworks}
+      networks={networks}
+      isFetchingNetworks={isFetchingNetworks}
+      isConnected={!!connectedNetwork}
+      connectedNetwork={connectedNetwork}
+      setConnectedNetwork={setConnectedNetwork}
+      fetchNetworksError={fetchNetworksError}
+      onSkipClick={runningOnWebRenderer() ? closeWifiWindow : undefined}
+      skipButtonLabel="Close"
+      showSkipWarning={false}
+    />
+  );
+};

--- a/frontend/src/pages/wifiPage/WifiPage.tsx
+++ b/frontend/src/pages/wifiPage/WifiPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import Layout from "../../components/layout/Layout";
 import Select from "../../components/atoms/select/Select";
@@ -12,6 +12,7 @@ import Button from "../../components/atoms/button/Button";
 import ConnectDialogContainer from "./connectDialog/ConnectDialogContainer";
 import SkipWarningDialog from "./skipWarningDialog/SkipWarningDialog";
 import { Network } from "../../types/Network";
+import usePrevious from "../../hooks/usePrevious";
 
 export enum ErrorMessage {
   FetchNetworks = "There was a problem getting networks, please refresh the networks list or skip",
@@ -24,9 +25,9 @@ export enum ExplanationMessage {
 }
 
 export type Props = {
-  onNextClick: () => void;
-  onSkipClick: () => void;
-  onBackClick: () => void;
+  onNextClick?: () => void;
+  onSkipClick?: () => void;
+  onBackClick?: () => void;
   onRefreshClick: () => void;
   networks: Network[];
   isFetchingNetworks: boolean;
@@ -34,6 +35,8 @@ export type Props = {
   isConnected: boolean;
   connectedNetwork?: Network;
   setConnectedNetwork: (network: Network) => void;
+  skipButtonLabel?: string;
+  showSkipWarning?: boolean;
 };
 
 export default ({
@@ -47,7 +50,10 @@ export default ({
   isConnected,
   connectedNetwork,
   setConnectedNetwork,
+  skipButtonLabel,
+  showSkipWarning = true,
 }: Props) => {
+  const previousConnectedNetwork = usePrevious(connectedNetwork);
   const [selectedNetwork, setSelectedNetwork] = useState(connectedNetwork);
   const [isConnectDialogActive, setIsConnectDialogActive] = useState(false);
   const [isSkipWarningDialogActive, setIsSkipWarningDialogActive] =
@@ -64,6 +70,15 @@ export default ({
     }
     return ExplanationMessage.NotConnected;
   };
+
+  useEffect(() => {
+    if (
+      connectedNetwork &&
+      previousConnectedNetwork?.bssid !== connectedNetwork?.bssid
+    ) {
+      setSelectedNetwork(connectedNetwork);
+    }
+  }, [connectedNetwork, previousConnectedNetwork]);
 
   return (
     <>
@@ -82,21 +97,28 @@ export default ({
           onClick: onNextClick,
           disabled: !isConnected,
         }}
-        skipButton={{ onClick: () => {
-          if (!isConnected) {
-            setIsSkipWarningDialogActive(true)
-          } else {
-            onSkipClick();
-          }
-        }}}
+        skipButton={{
+          label: skipButtonLabel,
+          onClick: () => {
+            if (!isConnected && showSkipWarning) {
+              setIsSkipWarningDialogActive(true);
+            } else if (onSkipClick) {
+              onSkipClick();
+            }
+          },
+        }}
         backButton={{ onClick: onBackClick }}
+        showBack={!!onBackClick}
+        showNext={!!onNextClick}
+        showSkip={!!onSkipClick}
       >
         <div className={styles.wifiSelectContainer}>
           <Select
             // force rerender when selected ssid changes
             key={selectedBSSID}
             value={
-              selectedBSSID && selectedSSID && {
+              selectedBSSID &&
+              selectedSSID && {
                 value: selectedBSSID,
                 label: selectedSSID,
               }
@@ -148,7 +170,7 @@ export default ({
         }}
         onDone={() => {
           setIsConnectDialogActive(false);
-          if (isConnected) {
+          if (isConnected && onNextClick) {
             onNextClick();
           }
         }}
@@ -156,7 +178,7 @@ export default ({
       <SkipWarningDialog
         active={isSkipWarningDialogActive}
         onConnectClick={() => setIsSkipWarningDialogActive(false)}
-        onSkipClick={onSkipClick}
+        onSkipClick={onSkipClick || (() => {})}
       />
     </>
   );

--- a/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
+++ b/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
@@ -1,0 +1,595 @@
+import React from "react";
+import {
+  render,
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+  wait,
+} from "@testing-library/react";
+import { rest } from "msw";
+
+import StandaloneWifiPageContainer from "../StandaloneWifiPageContainer";
+import { ErrorMessage, ExplanationMessage } from "../WifiPage";
+
+import queryReactSelect from "../../../../test/helpers/queryReactSelect";
+import querySpinner from "../../../../test/helpers/querySpinner";
+import { KeyCode } from "../../../../test/types/Keys";
+import { server } from "../../../msw/server";
+import networks from "../../../msw/data/networks.json";
+import textContentMatcher from "../../../../test/helpers/textContentMatcher";
+
+let mockUserAgent = "not-web-renderer";
+Object.defineProperty(window.navigator, "userAgent", {
+  get() {
+    return mockUserAgent;
+  },
+});
+
+const setRunningOnWebRenderer = (onWebRenderer = true) => {
+  mockUserAgent = onWebRenderer ? "web-renderer" : "not-web-renderer"
+};
+
+// increase timeout so failure messages are not timeout messages
+jest.setTimeout(10000);
+
+const fetchingNetworksMessage = "fetching networks...";
+
+const mount = () => render(<StandaloneWifiPageContainer />);
+
+describe("StandaloneWifiPageContainer", () => {
+  beforeEach(() => {
+    setRunningOnWebRenderer(false)
+  })
+
+  it("renders spinner while loading", async () => {
+    mount();
+
+    expect(querySpinner(document.body)).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+  });
+
+  it("renders correct message while loading", async () => {
+    mount();
+
+    expect(screen.queryByText(fetchingNetworksMessage)).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+  });
+
+  it("does not render buttons when using browser", async () => {
+    // use container bound queries to avoid dialogs
+    const { queryByText } = mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(queryByText("Back")).not.toBeInTheDocument();
+    expect(queryByText("Next")).not.toBeInTheDocument();
+    expect(queryByText("Done")).not.toBeInTheDocument();
+  });
+
+  it("does not render navigation buttons when using web-renderer", async () => {
+    setRunningOnWebRenderer(true)
+
+    // use container bound queries to avoid dialogs
+    const { queryByText } = mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(queryByText("Back")).not.toBeInTheDocument();
+    expect(queryByText("Next")).not.toBeInTheDocument();
+  });
+
+  it("can close window by clicking Close button when using web-renderer", async () => {
+    setRunningOnWebRenderer(true)
+
+    const closeWifiWindow = jest.fn((_, res, ctx) => res(ctx.json("OK")));
+    server.use(rest.post("/close-wifi-window", closeWifiWindow));
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(closeWifiWindow).not.toHaveBeenCalled();
+
+    // close button is rendered and clickable
+    fireEvent.click(screen.getByText("Close"))
+
+    // posts to close-wifi-window on close button click
+    await wait(() => {
+      expect(closeWifiWindow).toHaveBeenCalled();
+    });
+  });
+
+  it("renders correct explanation when not connected to network", async () => {
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(
+      screen.queryByText(ExplanationMessage.NotConnected)
+    ).toBeInTheDocument();
+  });
+
+  it("renders correct explanation when connected to network", async () => {
+    server.use(
+      rest.get("/current-wifi-bssid", (_, res, ctx) => {
+        return res(ctx.json(networks[0].bssid));
+      })
+    );
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(
+      screen.getByText(ExplanationMessage.WiFiConnection)
+    ).toBeInTheDocument();
+  });
+
+  it('shows correct connected network when already connected to network', async () => {
+    server.use(
+      rest.get("/current-wifi-bssid", (_, res, ctx) => {
+        return res(ctx.json(networks[0].bssid));
+      })
+    );
+
+    mount();
+
+    expect(await screen.findAllByText(networks[0].ssid)).toHaveLength(2)
+  })
+
+  it("renders error message when unable to get network", async () => {
+    server.use(
+      rest.get("/wifi-ssids", (_, res, ctx) => {
+        return res(ctx.status(401));
+      })
+    );
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(screen.queryByText(ErrorMessage.FetchNetworks)).toBeInTheDocument();
+  });
+
+  it("renders error message when unable to get current bssid", async () => {
+    server.use(
+      rest.get("/current-wifi-bssid", (_, res, ctx) => {
+        return res(ctx.status(401));
+      })
+    );
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    expect(screen.queryByText(ErrorMessage.FetchNetworks)).toBeInTheDocument();
+  });
+
+  it("renders networks in select when they are loaded successfully", async () => {
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    networks.forEach(({ ssid }) => {
+      expect(screen.queryByText(ssid)).toBeInTheDocument();
+    });
+  });
+
+  it("can refresh networks list when loading networks fails", async () => {
+    server.use(
+      rest.get("/wifi-ssids", (_, res, ctx) => {
+        return res(ctx.status(401));
+      })
+    );
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    server.resetHandlers();
+    fireEvent.click(screen.getByAltText("refresh-button"));
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    expect(screen.getByText("Depto 606")).toBeInTheDocument();
+  });
+
+  it("can refresh networks list when loading current bssid fails", async () => {
+    server.use(
+      rest.get("/current-wifi-bssid", (_, res, ctx) => {
+        return res(ctx.status(401));
+      })
+    );
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    server.resetHandlers();
+    fireEvent.click(screen.getByAltText("refresh-button"));
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    expect(screen.getByText("Depto 606")).toBeInTheDocument();
+  });
+
+
+
+  it("shows the connect dialog when network option is clicked", async () => {
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click a network option
+    fireEvent.click(screen.getByText(networks[0].ssid));
+
+    expect(screen.getByTestId("connect-dialog")).not.toHaveClass("hidden");
+  });
+
+  it("renders connect dialog message correctly when network requires password", async () => {
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    expect(
+      screen.getByText(
+        textContentMatcher(
+          `The WiFi network ${network.ssid} requires a password`
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("shows connection successful message after connecting to network", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // enter correct password
+    const passwordInputLabel = screen.getByLabelText("Enter password below");
+    fireEvent.change(passwordInputLabel, {
+      target: { value: "correct-password" },
+    });
+
+    // join network
+    fireEvent.click(screen.getByText("Join"));
+
+    // connecting message should be shown
+    expect(
+      screen.getByText(textContentMatcher(`Connecting to ${network.ssid}...`))
+    ).toBeInTheDocument();
+
+    // connected message should be shown eventually
+    expect(
+      await screen.findByText(
+        textContentMatcher(
+          `Great, your pi-top is connected to ${network.ssid}!`
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("prompts user to reconnect to pi-top network if disconnected while connecting to Wi-Fi", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // enter correct password
+    const passwordInputLabel = screen.getByLabelText("Enter password below");
+    fireEvent.change(passwordInputLabel, {
+      target: { value: "correct-password" },
+    });
+
+    // simulate wifi-creds failing and then  request hanging due to connection to pi-top being disrupted
+    server.use(
+      rest.post<{ bssid: string; password: string }>(
+        "/wifi-credentials",
+        (_, res, ctx) => {
+          return res(ctx.status(500));
+        }
+      ),
+      rest.get("/current-wifi-bssid", (_, res, ctx) => {
+        return res(ctx.delay(5000), ctx.status(400));
+      })
+    );
+
+    // join network
+    fireEvent.click(screen.getByText("Join"));
+
+    // reconnect to pi-top hotspot dialog should be shown
+    expect(
+      await screen.findByText("Reconnect to pi-top hotspot")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        textContentMatcher(
+          /Your computer has disconnected from the pi-top-XXXX Wi-Fi hotspot\. Please reconnect to it to continue onboarding/
+        )
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByAltText("Reconnect to pitop hotspot")
+    ).toBeInTheDocument();
+
+    // simulate user reconnecting to pitop hotspot
+    server.use(
+      rest.get("/current-wifi-bssid", (_, res, ctx) => {
+        return res(ctx.json(network.bssid));
+      })
+    );
+
+    // connected message should be shown eventually
+    expect(
+      await screen.findByText(
+        textContentMatcher(
+          `Great, your pi-top is connected to ${network.ssid}!`
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders error when incorrect password is used to connect to network", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // enter incorrect password
+    const passwordInputLabel = screen.getByLabelText("Enter password below");
+    fireEvent.change(passwordInputLabel, {
+      target: { value: "incorrect-password" },
+    });
+
+    // join network
+    fireEvent.click(screen.getByText("Join"));
+
+    expect(
+      await screen.findByText(
+        `There was an error connecting to ${network.ssid}... please check your password and try again`
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("clears incorrect password error when cancel is clicked and new network selected", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // enter incorrect password
+    const passwordInputLabel = screen.getByLabelText("Enter password below");
+    fireEvent.change(passwordInputLabel, {
+      target: { value: "incorrect-password" },
+    });
+
+    // join network
+    fireEvent.click(screen.getByText("Join"));
+
+    expect(
+      await screen.findByText(
+        `There was an error connecting to ${network.ssid}... please check your password and try again`
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // pick new network
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // error should not be rendered
+    expect(
+      screen.queryByText(
+        `There was an error connecting to ${network.ssid}... please check your password and try again`
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears incorrect password error when retry is clicked", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // enter incorrect password
+    const passwordInputLabel = screen.getByLabelText("Enter password below");
+    fireEvent.change(passwordInputLabel, {
+      target: { value: "incorrect-password" },
+    });
+
+    // join network
+    fireEvent.click(screen.getByText("Join"));
+
+    expect(
+      await screen.findByText(
+        `There was an error connecting to ${network.ssid}... please check your password and try again`
+      )
+    ).toBeInTheDocument();
+
+    // enter correct password and retry
+    fireEvent.change(passwordInputLabel, {
+      target: { value: "correct-password" },
+    });
+    fireEvent.click(screen.getByText("Retry"));
+
+    // it hides the error as soon as retry button is clicked
+    expect(
+      screen.queryByText(
+        `There was an error connecting to ${network.ssid}... please check your password and try again`
+      )
+    ).not.toBeInTheDocument();
+
+    // retried request succeeds
+    expect(
+      await screen.findByText(/Great, your pi-top is connected/)
+    ).toBeInTheDocument();
+  });
+
+  it("hides the connect dialog on connect dialog cancel click", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // cancel connecting to network
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // connect dialog should not be visible
+    expect(screen.getByTestId("connect-dialog")).toHaveClass("hidden");
+  });
+
+  it("resets selected network in select on connect dialog cancel click", async () => {
+    const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+
+    mount();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(fetchingNetworksMessage)
+    );
+
+    // open the select
+    fireEvent.keyDown(queryReactSelect(document.body)!, {
+      keyCode: KeyCode.DownArrow,
+    });
+
+    // click the wifi option
+    fireEvent.click(screen.getByText(network.ssid));
+
+    // cancel connecting to network
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // network should not be the selected option in the networks select
+    expect(screen.queryByText(network.ssid)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/closeWifiWindow.ts
+++ b/frontend/src/services/closeWifiWindow.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+import apiBaseUrl from "./apiBaseUrl";
+
+export default async function closeWifiWindow() {
+  await axios.post(
+    `${apiBaseUrl}/close-wifi-window`,
+    {},
+  );
+}

--- a/pt_os_web_portal/app_window/app_window.py
+++ b/pt_os_web_portal/app_window/app_window.py
@@ -73,6 +73,16 @@ class OsUpdaterAppWindow(AppWindow):
 
 
 @dataclass
+class WifiAppWindow(AppWindow):
+    url: str = "http://localhost/wifi"
+    width_scalar: float = 0.65
+    height_scalar: float = 0.7
+    title: str = "pi-topOS Wi-Fi"
+    icon: str = "/usr/share/icons/hicolor/scalable/apps/pt-os-about.svg"
+    hide_frame: bool = False
+
+
+@dataclass
 class LandingAppWindow(AppWindow):
     url: str = "http://localhost/landing"
     width_scalar: float = 0.65

--- a/pt_os_web_portal/backend/routes.py
+++ b/pt_os_web_portal/backend/routes.py
@@ -1,5 +1,4 @@
 import logging
-from enum import Enum
 from ipaddress import ip_address
 from json import dumps as jdumps
 from threading import Thread
@@ -74,25 +73,6 @@ def get_os_updater():
     return app.config["OS_UPDATER"]
 
 
-class FrontendAppRoutes(Enum):
-    LANDING = "/landing"
-    ONBOARDING = "/onboarding"
-    ABOUT = "/about"
-    UPDATER = "/updater"
-
-    @classmethod
-    def is_valid(cls, route):
-        try:
-            path = route
-            path_delimiter = route.find("/", 1)
-            if path_delimiter > 0:
-                path = route[:path_delimiter]
-            cls(str(path))
-        except ValueError:
-            return False
-        return True
-
-
 def abort_on_no_data(data):
     if data is None or (isinstance(data, str) and len(data) == 0):
         abort(400)
@@ -104,17 +84,13 @@ def index():
     logger.debug("Route '/'")
     if not onboarding_completed():
         logger.info("Onboarding not completed yet. Redirecting...")
-        return redirect(FrontendAppRoutes.ONBOARDING.value)
-    return redirect(FrontendAppRoutes.LANDING.value)
+        return redirect("/onboarding")
+
+    return app.send_static_file("index.html")
 
 
 @app.errorhandler(404)
 def not_found(e):
-    if not FrontendAppRoutes.is_valid(request.path) or (
-        FrontendAppRoutes.ONBOARDING.value not in request.path
-        and not onboarding_completed()
-    ):
-        return redirect("/")
     return app.send_static_file("index.html")
 
 

--- a/pt_os_web_portal/backend/routes.py
+++ b/pt_os_web_portal/backend/routes.py
@@ -11,6 +11,8 @@ from flask import redirect, request, send_from_directory
 from further_link.start_further import get_further_url
 from pitop.common.sys_info import InterfaceNetworkData, is_connected_to_internet
 
+from pt_os_web_portal.app_window.app_window import WifiAppWindow
+
 from ..app_window import LandingAppWindow, OsUpdaterAppWindow
 from ..event import AppEvents, post_event
 from ..pt_os_version_check import check_relevant_pi_top_os_version_updates
@@ -438,6 +440,13 @@ def post_disable_landing():
 def post_close_os_updater_window():
     logger.debug("Route '/close-os-updater-window'")
     OsUpdaterAppWindow().close()
+    return "OK"
+
+
+@app.route("/close-wifi-window", methods=["POST"])
+def post_close_wifi_window():
+    logger.debug("Route '/close-wifi-window'")
+    WifiAppWindow().close()
     return "OK"
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,26 +1,36 @@
-def send_static_file_mock(filename):
-    return "Mocked content", 200
+import pytest
 
 
-def test_redirect_on_404(app):
+@pytest.fixture(autouse=True)
+def mock_send_static_file(app, mocker):
+    mocker.patch.object(
+        app.application, "send_static_file", lambda _: "Mocked Content", 200
+    )
+
+
+def test_app_served(app, mocker):
+    mocker.patch(
+        "pt_os_web_portal.backend.routes.onboarding_completed", return_value=True
+    )
+    response = app.get("/", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert response.data == b"Mocked Content"
+
+
+def test_app_served_on_404(app):
     response = app.get("/non-existant-route", follow_redirects=False)
-    assert response.status_code == 302
-    assert response.location == "http://localhost/"
+
+    assert response.status_code == 200
+    assert response.data == b"Mocked Content"
 
 
-def test_404_redirect_to_onboarding_if_not_completed(app, mocker):
+def test_redirect_base_route_to_onboarding_if_not_completed(app, mocker):
     mocker.patch(
         "pt_os_web_portal.backend.routes.onboarding_completed", return_value=False
     )
-    mocker.patch.object(app.application, "send_static_file", send_static_file_mock)
 
-    response = app.get("/non-existant-route", follow_redirects=False)
-
-    # Request redirects to /
-    assert response.status_code == 302
-    assert response.location == "http://localhost/"
-
-    response = app.get(response.location, follow_redirects=False)
+    response = app.get("/", follow_redirects=False)
 
     # Request redirects to /onboarding
     assert response.status_code == 302
@@ -30,29 +40,4 @@ def test_404_redirect_to_onboarding_if_not_completed(app, mocker):
 
     # No more redirections
     assert response.status_code == 200
-    assert response.location is None
-
-
-def test_404_redirect_to_landing_if_onboarding_is_completed(app, mocker):
-    mocker.patch(
-        "pt_os_web_portal.backend.routes.onboarding_completed", return_value=True
-    )
-    mocker.patch.object(app.application, "send_static_file", send_static_file_mock)
-
-    response = app.get("/non-existant-route", follow_redirects=False)
-
-    # Request redirects to /
-    assert response.status_code == 302
-    assert response.location == "http://localhost/"
-
-    response = app.get(response.location, follow_redirects=False)
-
-    # Request redirects to /landing
-    assert response.status_code == 302
-    assert response.location == "http://localhost/landing"
-
-    response = app.get(response.location, follow_redirects=False)
-
-    # No more redirections
-    assert response.status_code == 200
-    assert response.location is None
+    assert response.data == b"Mocked Content"


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [OS-1267](https://pi-top.atlassian.net/browse/OS-1267) |


#### Main changes
[feat: add standalone wifi page](https://github.com/pi-top/pi-topOS-Web-Portal/pull/383/commits/78b81366a76b631b753e2c9ddc51a450af3ba164)

[chore: remove duplicated server and client routing](https://github.com/pi-top/pi-topOS-Web-Portal/pull/383/commits/8d4f11b2ada03be08ce439c8fd4d9de2571ab0f5)

Right now we are duplicating route matching on server and the client,
this means that any changes to the routes need to be matched on both
sides which is easy to miss or forget.

Remove the FrontendRoutes enum and corresponding is_valid class method
since that validation can be deferred to the client-side. The only time
we need server-side routing is when we need to redirect users opening
pi-top.local to /onboarding if it has not yet been completed.

We don't need to send users to /onboarding for every route if it has not
been completed.

Update client-side routing to fallback to Landing page to match the
existing routing behaviour.

A nice side-effect of this is that running the frontend without the
server doesn't show a blank screen when opened anymore.