### PR TITLE
fix: remove wifi and updater page close buttons

### DIFF
--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -11,8 +11,6 @@ import closeOsUpdaterWindow from "./services/closeOsUpdaterWindow";
 import LandingPage from "./pages/landingPage/LandingPage";
 import StandaloneWifiPageContainer from "./pages/wifiPage/StandaloneWifiPageContainer";
 
-import { runningOnWebRenderer } from "./helpers/utils";
-
 export default () => (
   <ErrorBoundary
     fallback={
@@ -31,8 +29,7 @@ export default () => (
           render={() => (
             <UpgradePageContainer
               goToNextPage={closeOsUpdaterWindow}
-              skipButtonLabel="Close"
-              hideSkip={!runningOnWebRenderer()}
+              hideSkip
             />
           )}
         />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,7 +1,9 @@
 import React, { ReactNode } from "react";
 import cx from "classnames";
 
-import PrimaryButton, { Props as ButtonProps } from "../primaryButton/PrimaryButton";
+import PrimaryButton, {
+  Props as ButtonProps,
+} from "../primaryButton/PrimaryButton";
 import Button from "../atoms/button/Button";
 import Spinner from "../atoms/spinner/Spinner";
 import styles from "./Layout.module.css";
@@ -46,9 +48,7 @@ export default ({
   className,
   isLoading,
 }: Props) => (
-
-
-  <div className={cx(styles.layout, className)}>
+  <div data-testid="layout" className={cx(styles.layout, className)}>
     {showHeader && <Header />}
     <div className={styles.banner}>
       <Image
@@ -62,10 +62,18 @@ export default ({
     </div>
 
     <div className={styles.content}>
-      {explanation && <span className={styles.explanation}>{explanation.split('\n').map(function (item, key) {
-        return (<span key={key}>{item}<br /></span>)
-      })
-      }</span>}
+      {explanation && (
+        <span className={styles.explanation}>
+          {explanation.split("\n").map(function (item, key) {
+            return (
+              <span key={key}>
+                {item}
+                <br />
+              </span>
+            );
+          })}
+        </span>
+      )}
 
       {children}
 
@@ -83,9 +91,11 @@ export default ({
         {isLoading ? (
           <Spinner size={60} />
         ) : (
-          showNext && <PrimaryButton {...nextButton}>
-            {nextButton.label ? nextButton.label : "Next"}
-          </PrimaryButton>
+          showNext && (
+            <PrimaryButton {...nextButton}>
+              {nextButton.label ? nextButton.label : "Next"}
+            </PrimaryButton>
+          )
         )}
 
         <div className={styles.skipButtonContainer}>

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -38,7 +38,6 @@ export type Props = {
   onNextClick?: () => void;
   onSkipClick?: () => void;
   onBackClick?: () => void;
-  skipButtonLabel?: string;
   onStartUpgradeClick: () => void;
   onRetry: (defaultBackend: boolean) => void;
   isCompleted?: boolean;
@@ -55,7 +54,6 @@ export default ({
   onSkipClick,
   onBackClick,
   onNextClick,
-  skipButtonLabel,
   onStartUpgradeClick,
   onRetry,
   updateState,
@@ -183,7 +181,7 @@ export default ({
           disabled: !hasError() && nextButtonDisabledStates.includes(updateState),
           hidden: error === ErrorType.UpdaterAlreadyRunning || (updateState === UpdateState.Finished && runsUpdaterStandaloneAppInBrowser)
         }}
-        skipButton={{ onClick: onSkipClick, label: skipButtonLabel }}
+        skipButton={{ onClick: onSkipClick }}
         showSkip={!hideSkip && onSkipClick !== undefined && (hasError() || isCompleted === true)}
         showBack={onBackClick !== undefined && (hasError() || showBackButtonStates.includes(updateState))}
         backButton={{

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -100,11 +100,10 @@ export type Props = {
   goToNextPage?: () => void;
   goToPreviousPage?: () => void;
   hideSkip?: boolean;
-  skipButtonLabel?: string;
   isCompleted?: boolean;
 };
 
-export default ({ goToNextPage, goToPreviousPage, hideSkip, skipButtonLabel, isCompleted }: Props) => {
+export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props) => {
   const [message, setMessage] = useState<OSUpdaterMessage>();
   const [isOpen, setIsOpen] = useState(false);
   document.title = "pi-topOS System Update"
@@ -345,7 +344,6 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, skipButtonLabel, isC
       onSkipClick={goToNextPage}
       onBackClick={goToPreviousPage}
       hideSkip={hideSkip}
-      skipButtonLabel={skipButtonLabel}
       onStartUpgradeClick={() => {
         if (isOpen) {
           setState(UpdateState.UpgradingSystem);

--- a/frontend/src/pages/wifiPage/StandaloneWifiPageContainer.tsx
+++ b/frontend/src/pages/wifiPage/StandaloneWifiPageContainer.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from "react";
 
 import WifiPage from "./WifiPage";
 import { Network } from "../../types/Network";
-import closeWifiWindow from "../../services/closeWifiWindow";
-import { runningOnWebRenderer } from "../../helpers/utils";
 import getNetworks from "../../services/getNetworks";
 import connectedBSSID from "../../services/connectedBSSID";
 
@@ -45,8 +43,6 @@ export default () => {
       connectedNetwork={connectedNetwork}
       setConnectedNetwork={setConnectedNetwork}
       fetchNetworksError={fetchNetworksError}
-      onSkipClick={runningOnWebRenderer() ? closeWifiWindow : undefined}
-      skipButtonLabel="Close"
       showSkipWarning={false}
     />
   );

--- a/frontend/src/pages/wifiPage/WifiPage.tsx
+++ b/frontend/src/pages/wifiPage/WifiPage.tsx
@@ -35,7 +35,6 @@ export type Props = {
   isConnected: boolean;
   connectedNetwork?: Network;
   setConnectedNetwork: (network: Network) => void;
-  skipButtonLabel?: string;
   showSkipWarning?: boolean;
 };
 
@@ -50,7 +49,6 @@ export default ({
   isConnected,
   connectedNetwork,
   setConnectedNetwork,
-  skipButtonLabel,
   showSkipWarning = true,
 }: Props) => {
   const previousConnectedNetwork = usePrevious(connectedNetwork);
@@ -98,7 +96,6 @@ export default ({
           disabled: !isConnected,
         }}
         skipButton={{
-          label: skipButtonLabel,
           onClick: () => {
             if (!isConnected && showSkipWarning) {
               setIsSkipWarningDialogActive(true);

--- a/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
+++ b/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   waitForElementToBeRemoved,
   wait,
+  within,
 } from "@testing-library/react";
 import { rest } from "msw";
 
@@ -62,53 +63,31 @@ describe("StandaloneWifiPageContainer", () => {
   });
 
   it("does not render buttons when using browser", async () => {
-    // use container bound queries to avoid dialogs
-    const { queryByText } = mount();
+    const { getByTestId } = mount();
+    const layout = getByTestId('layout')
 
     await waitForElementToBeRemoved(() =>
       screen.getByText(fetchingNetworksMessage)
     );
 
-    expect(queryByText("Back")).not.toBeInTheDocument();
-    expect(queryByText("Next")).not.toBeInTheDocument();
-    expect(queryByText("Done")).not.toBeInTheDocument();
+    expect(within(layout).queryByText("Back")).not.toBeInTheDocument();
+    expect(within(layout).queryByText("Next")).not.toBeInTheDocument();
+    expect(within(layout).queryByText('Skip')).not.toBeInTheDocument()
   });
 
   it("does not render navigation buttons when using web-renderer", async () => {
     setRunningOnWebRenderer(true)
 
-    // use container bound queries to avoid dialogs
-    const { queryByText } = mount();
+    const { getByTestId } = mount();
+    const layout = getByTestId('layout')
 
     await waitForElementToBeRemoved(() =>
       screen.getByText(fetchingNetworksMessage)
     );
 
-    expect(queryByText("Back")).not.toBeInTheDocument();
-    expect(queryByText("Next")).not.toBeInTheDocument();
-  });
-
-  it("can close window by clicking Close button when using web-renderer", async () => {
-    setRunningOnWebRenderer(true)
-
-    const closeWifiWindow = jest.fn((_, res, ctx) => res(ctx.json("OK")));
-    server.use(rest.post("/close-wifi-window", closeWifiWindow));
-
-    mount();
-
-    await waitForElementToBeRemoved(() =>
-      screen.getByText(fetchingNetworksMessage)
-    );
-
-    expect(closeWifiWindow).not.toHaveBeenCalled();
-
-    // close button is rendered and clickable
-    fireEvent.click(screen.getByText("Close"))
-
-    // posts to close-wifi-window on close button click
-    await wait(() => {
-      expect(closeWifiWindow).toHaveBeenCalled();
-    });
+    expect(within(layout).queryByText("Back")).not.toBeInTheDocument();
+    expect(within(layout).queryByText("Next")).not.toBeInTheDocument();
+    expect(within(layout).queryByText('Skip')).not.toBeInTheDocument()
   });
 
   it("renders correct explanation when not connected to network", async () => {

--- a/pt_os_web_portal/backend/routes.py
+++ b/pt_os_web_portal/backend/routes.py
@@ -10,9 +10,7 @@ from flask import redirect, request, send_from_directory
 from further_link.start_further import get_further_url
 from pitop.common.sys_info import InterfaceNetworkData, is_connected_to_internet
 
-from pt_os_web_portal.app_window.app_window import WifiAppWindow
-
-from ..app_window import LandingAppWindow, OsUpdaterAppWindow
+from ..app_window import LandingAppWindow
 from ..event import AppEvents, post_event
 from ..pt_os_version_check import check_relevant_pi_top_os_version_updates
 from . import sockets
@@ -412,20 +410,6 @@ def get_python_sdk_docs_url():
 def post_disable_landing():
     logger.debug("Route '/disable-landing'")
     disable_landing()
-    return "OK"
-
-
-@app.route("/close-os-updater-window", methods=["POST"])
-def post_close_os_updater_window():
-    logger.debug("Route '/close-os-updater-window'")
-    OsUpdaterAppWindow().close()
-    return "OK"
-
-
-@app.route("/close-wifi-window", methods=["POST"])
-def post_close_wifi_window():
-    logger.debug("Route '/close-wifi-window'")
-    WifiAppWindow().close()
     return "OK"
 
 


### PR DESCRIPTION
When showing the standalone wifi and updater pages using the
web-renderer we show custom close buttons that hit an endpoint to close
the window. This was done in the past since the window frame was not
being shown and so there was no close button rendered. The wifi and
updater pages are being shown with the window frame visible however, so
we don't need the custom close buttons.