### PR TITLE
fix: hide finish button in standalone updater

### DIFF
--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -7,7 +7,6 @@ import RestartPageContainer from "./pages/restartPage/RestartPageContainer";
 import ErrorPage from "./pages/errorPage/ErrorPage";
 import AboutPageContainer from "./pages/aboutPage/AboutPageContainer";
 import UpgradePageContainer from "./pages/upgradePage/UpgradePageContainer";
-import closeOsUpdaterWindow from "./services/closeOsUpdaterWindow";
 import LandingPage from "./pages/landingPage/LandingPage";
 import StandaloneWifiPageContainer from "./pages/wifiPage/StandaloneWifiPageContainer";
 
@@ -26,12 +25,7 @@ export default () => (
         <Route path="/wifi" component={StandaloneWifiPageContainer} />
         <Route
           path="/updater"
-          render={() => (
-            <UpgradePageContainer
-              goToNextPage={closeOsUpdaterWindow}
-              hideSkip
-            />
-          )}
+          render={() => <UpgradePageContainer hideSkip />}
         />
         <Route component={LandingPage} />
       </Switch>

--- a/frontend/src/pages/upgradePage/UpgradePage.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePage.tsx
@@ -9,10 +9,15 @@ import Spinner from "../../components/atoms/spinner/Spinner";
 import upgradePage from "../../assets/images/upgrade-page.png";
 import styles from "./UpgradePage.module.css";
 
-import { ErrorType, OSUpdaterMessage, OSUpdaterMessageType, UpdateMessageStatus, UpdateState } from "./UpgradePageContainer"
+import {
+  ErrorType,
+  OSUpdaterMessage,
+  OSUpdaterMessageType,
+  UpdateMessageStatus,
+  UpdateState,
+} from "./UpgradePageContainer";
 import NewOsVersionDialogContainer from "./newOsVersionDialog/NewOsVersionDialogContainer";
 import UpgradeHistoryTextArea from "../../components/upgradeHistoryTextArea/UpgradeHistoryTextArea";
-import { runningOnWebRenderer } from "../../helpers/utils";
 
 export enum ErrorMessage {
   NoSpaceAvailable = "There's not enough space on the device to install updates. Please, free up space and try updating again.",
@@ -24,15 +29,14 @@ export enum UpgradePageExplanation {
   UpgradePreparedWithDownload = "{size} of new packages need to be installed. This might take {time} minutes.",
   UpgradePreparedWithoutDownload = "Some packages need to be installed. This might take a few minutes.",
   InProgress = "Now sit back and relax - this may take some time...\nPlease, DO NOT POWER OFF YOUR DEVICE!",
-  FinishStandaloneUpdaterAppOnWebBrowser = "Great, system update has been successfully installed!\n\nYou can now close this window.",
-  Finish = "Great, system update has been successfully installed!\n\nPlease click the {continueButtonLabel} button to {continueButtonAction}.",
+  FinishStandalone = "Great, system update has been successfully installed!\n\nYou can now close this window.",
+  Finish = "Great, system update has been successfully installed!\n\nPlease click the Next button to continue.",
   WaitingForServer = "Please wait...",
   UpdatingSources = "Checking to see if there are updates available...",
   Preparing = "Preparing all packages to be updated...",
   PreparingWebPortal = "Preparing to update myself...",
   UpdatingWebPortal = "I'm updating myself, please wait...",
 }
-
 
 export type Props = {
   onNextClick?: () => void;
@@ -41,13 +45,13 @@ export type Props = {
   onStartUpgradeClick: () => void;
   onRetry: (defaultBackend: boolean) => void;
   isCompleted?: boolean;
-  message?: OSUpdaterMessage,
-  updateState: UpdateState,
-  downloadSize: number,
-  error: ErrorType,
-  requireBurn: boolean,
-  hideSkip?: boolean,
-  shouldBurn: boolean,
+  message?: OSUpdaterMessage;
+  updateState: UpdateState;
+  downloadSize: number;
+  error: ErrorType;
+  requireBurn: boolean;
+  hideSkip?: boolean;
+  shouldBurn: boolean;
 };
 
 export default ({
@@ -74,8 +78,8 @@ export default ({
   }, [requireBurn, shouldBurn]);
 
   const hasError = () => {
-    return error !== ErrorType.None
-  }
+    return error !== ErrorType.None;
+  };
 
   const getErrorMessage = () => {
     switch (error) {
@@ -84,36 +88,54 @@ export default ({
       case ErrorType.UpdaterAlreadyRunning:
         return ErrorMessage.CloseOtherWindow;
       default:
-        return ErrorMessage.GenericError
+        return ErrorMessage.GenericError;
     }
-  }
+  };
 
   const getPromptMessage = () => {
     if (updateState === UpdateState.Finished) {
-      return <>Your system is <span className="green">up to date</span>!</>
+      return (
+        <>
+          Your system is <span className="green">up to date</span>!
+        </>
+      );
     } else if (isRetrying) {
-      return <>OK, let's try <span className="green">updating</span> again!</>
+      return (
+        <>
+          OK, let's try <span className="green">updating</span> again!
+        </>
+      );
     }
-    return <>OK, I need to be <span className="green">updated</span></>
-  }
+    return (
+      <>
+        OK, I need to be <span className="green">updated</span>
+      </>
+    );
+  };
 
   const parseMessage = (message: OSUpdaterMessage) => {
-    if (message?.type === OSUpdaterMessageType.UpdateSources || message?.type === OSUpdaterMessageType.Upgrade || message?.type === OSUpdaterMessageType.PrepareUpgrade) {
-      let msg = JSON.stringify(message.payload?.message).trim().replace(/^"(.*)"$/, '$1')
+    if (
+      message?.type === OSUpdaterMessageType.UpdateSources ||
+      message?.type === OSUpdaterMessageType.Upgrade ||
+      message?.type === OSUpdaterMessageType.PrepareUpgrade
+    ) {
+      let msg = JSON.stringify(message.payload?.message)
+        .trim()
+        .replace(/^"(.*)"$/, "$1")
         .replace(/\\\\n/g, String.fromCharCode(10));
       if (message.payload.status === UpdateMessageStatus.Error) {
         // Add a newline before an ERROR message
         msg = String.fromCharCode(13, 10) + msg;
       }
 
-      return msg
+      return msg;
     }
-    return ""
-  }
+    return "";
+  };
 
   const getExplanation = () => {
     if (error) {
-      return ""
+      return "";
     }
 
     switch (updateState) {
@@ -131,40 +153,66 @@ export default ({
         return UpgradePageExplanation.InProgress;
       case UpdateState.WaitingForUserInput:
         if (downloadSize) {
-          return UpgradePageExplanation.UpgradePreparedWithDownload
-            .replace("{size}", prettyBytes(downloadSize))
-            .replace("{time}", "a few");
+          return UpgradePageExplanation.UpgradePreparedWithDownload.replace(
+            "{size}",
+            prettyBytes(downloadSize)
+          ).replace("{time}", "a few");
         }
         return UpgradePageExplanation.UpgradePreparedWithoutDownload;
       case UpdateState.Finished:
-        if (runsUpdaterStandaloneAppInBrowser) {
-          return UpgradePageExplanation.FinishStandaloneUpdaterAppOnWebBrowser
+        if (!onNextClick) {
+          return UpgradePageExplanation.FinishStandalone;
         }
-        return UpgradePageExplanation.Finish.replace(
-          "{continueButtonLabel}",
-          continueButtonLabel
-        ).replace("{continueButtonAction}", onBackClick? "continue" : "finish");
+        return UpgradePageExplanation.Finish;
       default:
-        return ""
-    };
+        return "";
+    }
   };
 
-  const continueButtonLabel = hasError() ? "Retry" : updateState !== UpdateState.Finished ? "Update" : onBackClick? "Next" : "Exit";
-  const nextButtonDisabledStates = [UpdateState.WaitingForServer, UpdateState.None, UpdateState.UpdatingSources, UpdateState.PreparingSystemUpgrade, UpdateState.PreparingWebPortal, UpdateState.UpgradingSystem, UpdateState.UpgradingWebPortal, UpdateState.Connect, UpdateState.Reattaching];
-  const backButtonDisabledStates = [UpdateState.UpdatingSources, UpdateState.UpgradingSystem, UpdateState.UpgradingWebPortal, UpdateState.Connect, UpdateState.Reattaching, UpdateState.PreparingWebPortal];
-  const showBackButtonStates = [UpdateState.Error, UpdateState.WaitingForUserInput, UpdateState.Finished];
-  const runsUpdaterStandaloneAppInBrowser = !runningOnWebRenderer() && onBackClick === undefined;
+  const showNextButton =
+    (hasError() && error !== ErrorType.UpdaterAlreadyRunning) ||
+    updateState !== UpdateState.Finished ||
+    !!onNextClick;
+  const nextButtonLabel = hasError()
+    ? "Retry"
+    : updateState !== UpdateState.Finished
+    ? "Update"
+    : "Next";
+  const nextButtonDisabledStates = [
+    UpdateState.WaitingForServer,
+    UpdateState.None,
+    UpdateState.UpdatingSources,
+    UpdateState.PreparingSystemUpgrade,
+    UpdateState.PreparingWebPortal,
+    UpdateState.UpgradingSystem,
+    UpdateState.UpgradingWebPortal,
+    UpdateState.Connect,
+    UpdateState.Reattaching,
+  ];
+  const backButtonDisabledStates = [
+    UpdateState.UpdatingSources,
+    UpdateState.UpgradingSystem,
+    UpdateState.UpgradingWebPortal,
+    UpdateState.Connect,
+    UpdateState.Reattaching,
+    UpdateState.PreparingWebPortal,
+  ];
+  const showBackButtonStates = [
+    UpdateState.Error,
+    UpdateState.WaitingForUserInput,
+    UpdateState.Finished,
+  ];
 
   const onNextButtonClick = () => {
     if (hasError()) {
-        setIsRetrying(true);
-        onRetry(isUsingDefaultBackend)
+      setIsRetrying(true);
+      onRetry(isUsingDefaultBackend);
     } else if (updateState === UpdateState.WaitingForUserInput) {
       onStartUpgradeClick();
     } else {
       onNextClick && onNextClick();
     }
-  }
+  };
 
   return (
     <>
@@ -177,37 +225,53 @@ export default ({
         explanation={getExplanation()}
         nextButton={{
           onClick: onNextButtonClick,
-          label: continueButtonLabel,
-          disabled: !hasError() && nextButtonDisabledStates.includes(updateState),
-          hidden: error === ErrorType.UpdaterAlreadyRunning || (updateState === UpdateState.Finished && runsUpdaterStandaloneAppInBrowser)
+          label: nextButtonLabel,
+          disabled:
+            !hasError() && nextButtonDisabledStates.includes(updateState),
+          hidden: !showNextButton,
         }}
         skipButton={{ onClick: onSkipClick }}
-        showSkip={!hideSkip && onSkipClick !== undefined && (hasError() || isCompleted === true)}
-        showBack={onBackClick !== undefined && (hasError() || showBackButtonStates.includes(updateState))}
+        showSkip={
+          !hideSkip &&
+          onSkipClick !== undefined &&
+          (hasError() || isCompleted === true)
+        }
+        showBack={
+          onBackClick !== undefined &&
+          (hasError() || showBackButtonStates.includes(updateState))
+        }
         backButton={{
           onClick: onBackClick,
-          disabled: !hasError() && backButtonDisabledStates.includes(updateState)
+          disabled:
+            !hasError() && backButtonDisabledStates.includes(updateState),
         }}
       >
-        { hasError() && (
+        {hasError() && (
           <>
-          <span className={styles.error}>
-            {
-              getErrorMessage().split('\n').map(function(item, key) {
-                return (<span key={key}>{item}<br/></span>)
-              })
-            }
-          </span>
+            <span className={styles.error}>
+              {getErrorMessage()
+                .split("\n")
+                .map(function (item, key) {
+                  return (
+                    <span key={key}>
+                      {item}
+                      <br />
+                    </span>
+                  );
+                })}
+            </span>
 
-          { error !== ErrorType.UpdaterAlreadyRunning &&
-            <CheckBox
-              name="legacy-backend"
-              label="Use alternate update method"
-              checked={!isUsingDefaultBackend}
-              onChange={() => setIsUsingDefaultBackend(!isUsingDefaultBackend)}
-              className={styles.checkbox}
-            />
-          }
+            {error !== ErrorType.UpdaterAlreadyRunning && (
+              <CheckBox
+                name="legacy-backend"
+                label="Use alternate update method"
+                checked={!isUsingDefaultBackend}
+                onChange={() =>
+                  setIsUsingDefaultBackend(!isUsingDefaultBackend)
+                }
+                className={styles.checkbox}
+              />
+            )}
           </>
         )}
 
@@ -218,25 +282,31 @@ export default ({
           onClose={() => setIsNewOsDialogActive(false)}
         />
 
-        { updateState !== UpdateState.WaitingForServer && message && message?.type === OSUpdaterMessageType.Upgrade &&
-          <UpgradeHistoryTextArea message={parseMessage(message)} />
-        }
+        {updateState !== UpdateState.WaitingForServer &&
+          message &&
+          message?.type === OSUpdaterMessageType.Upgrade && (
+            <UpgradeHistoryTextArea message={parseMessage(message)} />
+          )}
 
-        { updateState !== UpdateState.WaitingForServer && message && message?.type === OSUpdaterMessageType.UpdateSources &&
-          <UpgradeHistoryTextArea message={parseMessage(message)} />
-        }
+        {updateState !== UpdateState.WaitingForServer &&
+          message &&
+          message?.type === OSUpdaterMessageType.UpdateSources && (
+            <UpgradeHistoryTextArea message={parseMessage(message)} />
+          )}
 
-        { !hasError() && (updateState === UpdateState.WaitingForServer || updateState === UpdateState.Reattaching ) && (
-          <>
-            <Spinner size={40} />{" "}
-          </>
-        )}
+        {!hasError() &&
+          (updateState === UpdateState.WaitingForServer ||
+            updateState === UpdateState.Reattaching) && (
+            <>
+              <Spinner size={40} />{" "}
+            </>
+          )}
 
-        {(message?.type === OSUpdaterMessageType.Upgrade || message?.type === OSUpdaterMessageType.UpdateSources)
-          && updateState !== UpdateState.WaitingForServer
-          && !hasError()
-          && isUsingDefaultBackend
-          && (
+        {(message?.type === OSUpdaterMessageType.Upgrade ||
+          message?.type === OSUpdaterMessageType.UpdateSources) &&
+          updateState !== UpdateState.WaitingForServer &&
+          !hasError() &&
+          isUsingDefaultBackend && (
             <div data-testid="progress" className={styles.progress}>
               <ProgressBar
                 percent={message.payload.percent}
@@ -244,8 +314,7 @@ export default ({
                 strokeColor="#71c0b4"
               />
             </div>
-          )
-        }
+          )}
       </Layout>
     </>
   );


### PR DESCRIPTION
The Finish button in the standalone updater does not work when using the
web-renderer, this might be a backend problem. We don't actually want
users to click the Finish button anyways though as the window has it's
own close button.

Hide the finish button when standlone and update the messages to
indicate the window can be closed by the user.
