### PR TITLE
refactor: use new core in miniscreen onboarding

### DIFF
--- a/pt_os_web_portal/miniscreen_onboarding_assistant/onboarding_assistant_app.py
+++ b/pt_os_web_portal/miniscreen_onboarding_assistant/onboarding_assistant_app.py
@@ -10,14 +10,18 @@ logger = logging.getLogger(__name__)
 
 class OnboardingAssistantApp(BaseApp):
     def __init__(self):
-        miniscreen = Pitop().miniscreen
+        self.miniscreen = Pitop().miniscreen
 
-        miniscreen.select_button.when_released = self.handle_select_button_release
-        miniscreen.cancel_button.when_released = self.handle_cancel_button_release
-        miniscreen.up_button.when_released = self.handle_up_button_release
-        miniscreen.down_button.when_released = self.handle_down_button_release
+        self.miniscreen.select_button.when_released = self.handle_select_button_release
+        self.miniscreen.cancel_button.when_released = self.handle_cancel_button_release
+        self.miniscreen.up_button.when_released = self.handle_up_button_release
+        self.miniscreen.down_button.when_released = self.handle_down_button_release
 
-        super().__init__(miniscreen, Root=RootComponent)
+        super().__init__(
+            display=self.miniscreen.device.display,
+            Root=RootComponent,
+            size=self.miniscreen.size,
+        )
 
     def handle_select_button_release(self):
         self.root.handle_select_button()


### PR DESCRIPTION
Update the miniscreen onboarding app to use the new core App class that accepts a display and size method rather than the miniscreen.

See https://github.com/pi-top/pi-top-4-Miniscreen/pull/289

NOTE: draft until the related changes are merged.
