### PR TITLE
Stop polling for AP credentials once they're retrieved

### DIFF
--- a/pt_os_web_portal/connection_manager.py
+++ b/pt_os_web_portal/connection_manager.py
@@ -13,37 +13,13 @@ from .event import AppEvents, post_event
 logger = logging.getLogger(__name__)
 
 
-class ApConnection:
-    def __init__(self):
-        self.metadata = get_ap_mode_status()
-        self._previous_metadata = None
-        self._has_changes = True
-
-    @property
-    def ssid(self):
-        return self.metadata.get("ssid", "")
-
-    @property
-    def passphrase(self):
-        return self.metadata.get("passphrase", "")
-
-    @property
-    def has_changes(self):
-        return self._has_changes
-
-    def update(self):
-        self.metadata = get_ap_mode_status()
-        self._has_changes = self.metadata != self._previous_metadata
-        self._previous_metadata = self.metadata
-
-
 class ConnectionManager:
     SLEEP_TIME = 0.5
 
     def __init__(self):
-        self.ap_connection = ApConnection()
         self.__thread = Thread(target=self._main, args=())
         self._stop = False
+        self._emmited_ap_credentials = False
         self._previous_connection_state = False
         self._previous_connected_device_ip = ""
 
@@ -60,10 +36,15 @@ class ConnectionManager:
 
     def _main(self):
         while not self._stop:
-            self.ap_connection.update()
-            if self.ap_connection.has_changes:
-                post_event(AppEvents.AP_HAS_SSID, self.ap_connection.ssid)
-                post_event(AppEvents.AP_HAS_PASSPHRASE, self.ap_connection.passphrase)
+
+            if not self._emmited_ap_credentials:
+                ap_credentials = get_ap_mode_status()
+                ssid = ap_credentials.get("ssid", "")
+                passphrase = ap_credentials.get("passphrase", "")
+                if ssid != "" and passphrase != "":
+                    post_event(AppEvents.AP_HAS_SSID, ssid)
+                    post_event(AppEvents.AP_HAS_PASSPHRASE, passphrase)
+                    self._emmited_ap_credentials = True
 
             connected_device_ip = get_address_for_connected_device()
             if connected_device_ip != self._previous_connected_device_ip:

--- a/pt_os_web_portal/connection_manager.py
+++ b/pt_os_web_portal/connection_manager.py
@@ -19,7 +19,7 @@ class ConnectionManager:
     def __init__(self):
         self.__thread = Thread(target=self._main, args=())
         self._stop = False
-        self._emmited_ap_credentials = False
+        self._emitted_ap_credentials = False
         self._previous_connection_state = False
         self._previous_connected_device_ip = ""
 
@@ -37,14 +37,14 @@ class ConnectionManager:
     def _main(self):
         while not self._stop:
 
-            if not self._emmited_ap_credentials:
+            if not self._emitted_ap_credentials:
                 ap_credentials = get_ap_mode_status()
                 ssid = ap_credentials.get("ssid", "")
                 passphrase = ap_credentials.get("passphrase", "")
                 if ssid != "" and passphrase != "":
                     post_event(AppEvents.AP_HAS_SSID, ssid)
                     post_event(AppEvents.AP_HAS_PASSPHRASE, passphrase)
-                    self._emmited_ap_credentials = True
+                    self._emitted_ap_credentials = True
 
             connected_device_ip = get_address_for_connected_device()
             if connected_device_ip != self._previous_connected_device_ip:


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1401) |


#### Main changes

Stop polling for AP credentials once they're successfully retrieved; old behavior caused credentials to be blanked if the command that runs in the background failed for some reason.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
- Install PR artifacts.
- Set web-portal state to 'not onboarded' with `sudo sed -i 's|onboarded = true|onboarded = false|g' /var/lib/pt-os-web-portal/state.cfg`.
- Restart web portal service with `sudo systemctl restart pt-os-web-portal`
- Go through the miniscreen onboarding app and make sure the AP mode credentials aren't randomly cleared out.
- Once testing finishes, restore old state with `sudo sed -i 's|onboarded = false|onboarded = true|g' /var/lib/pt-os-web-portal/state.cfg`.

#### Tag anyone who definitely needs to review or help
-
