### PR TITLE
Ping next-page url to determine server status

### DIFF
--- a/frontend/src/hooks/useSocket.tsx
+++ b/frontend/src/hooks/useSocket.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 
 export default function useSocket(url: string) {
-  const socketRef = useRef<WebSocket>(new WebSocket(url));
+  const [socket, setSocket] = useState<WebSocket>(() => new WebSocket(url));
 
   useEffect(() => {
-    const socket = socketRef.current;
     return () => socket.close();
-  }, []);
+  }, [socket]);
 
-  return socketRef.current;
+  return [socket, () => setSocket(new WebSocket(url))] as const;
 }

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -1,3 +1,4 @@
+import axios from "axios"
 import React, { useCallback, useRef, useState, useEffect } from "react";
 
 import UpgradePage from "./UpgradePage";
@@ -8,7 +9,6 @@ import usePrevious from "../../hooks/usePrevious";
 import getAvailableSpace from "../../services/getAvailableSpace";
 import wsBaseUrl from "../../services/wsBaseUrl";
 import restartWebPortalService from "../../services/restartWebPortalService";
-import serverStatus from "../../services/serverStatus"
 import getMajorOsUpdates from "../../services/getMajorOsUpdates"
 
 export enum OSUpdaterMessageType {
@@ -226,10 +226,12 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props
       try {
         elapsedWaitingTimeMs += timeoutServerStatusRequestMs + serverStatusRequestIntervalMs;
         elapsedWaitingTimeMs >= serviceRestartTimoutMs && setError(ErrorType.GenericError);
-        serverStatus({ timeout: timeoutServerStatusRequestMs })
-          .then(() => clearInterval(interval))
-          .catch(() => {})
-        window.location.replace(window.location.pathname + "?all")
+
+        axios.get(window.location.href + "?all")
+          .then(() => {
+            clearInterval(interval);
+            window.location.replace(window.location.pathname + "?all");
+          })
       } catch (_) {}
     }, serverStatusRequestIntervalMs);
   }

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -108,7 +108,7 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props
   const [isOpen, setIsOpen] = useState(false);
   document.title = "pi-topOS System Update"
 
-  const socket = useSocket(`${wsBaseUrl}/os-upgrade`, );
+  const [socket, reconnectSocket] = useSocket(`${wsBaseUrl}/os-upgrade`, );
   socket.onmessage = (e: MessageEvent) => {
     try {
       const data = JSON.parse(e.data);
@@ -117,6 +117,9 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props
   };
   socket.onopen = () => {
     setIsOpen(true);
+  }
+  socket.onerror = () => {
+    setTimeout(reconnectSocket, 1000);
   }
 
   const [updateSize, setUpdateSize] = useState({downloadSize: 0, requiredSpace: 0});

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -232,27 +232,23 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props
         elapsedWaitingTimeMs >= serviceRestartTimoutMs && setError(ErrorType.GenericError);
 
         await axios.get(
-            window.location.href + "?all",
-            {
-              headers: {
-                'Cache-Control': 'no-cache',
-                'Pragma': 'no-cache',
-                'Expires': '0',
-              },
-            }
-          )
-          .then(() => {
-            return new Promise((res, rej) => {
-              const testSocket = new WebSocket(`${wsBaseUrl}/os-upgrade`);
-              testSocket.onopen = res;
-              testSocket.onerror = rej;
-            })
-          })
-          .then(() => {
-            clearInterval(interval);
-            window.location.replace(window.location.pathname + "?all");
-          })
-      } catch (_) {}
+          window.location.href + "?all",
+          {
+            headers: {
+              'Cache-Control': 'no-cache',
+              'Pragma': 'no-cache',
+              'Expires': '0',
+            },
+          }
+        );
+        await new Promise((res, rej) => {
+          const testSocket = new WebSocket(`${wsBaseUrl}/os-upgrade`);
+          testSocket.onopen = res;
+          testSocket.onerror = () => rej(new Error('socket not ready'));
+        })
+        clearInterval(interval);
+        window.location.replace(window.location.pathname + "?all");
+      } catch (_) { };
     }, serverStatusRequestIntervalMs);
   }
 

--- a/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
+++ b/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
@@ -809,7 +809,7 @@ describe("UpgradePageContainer", () => {
       jest.runOnlyPendingTimers();
       jest.runOnlyPendingTimers();
 
-      expect(axios.get).toHaveBeenCalledWith(window.location.pathname + "?all");
+      expect(axios.get).toHaveBeenCalledWith(window.location.pathname + "?all", {"headers": {"Cache-Control": "no-cache", "Expires": "0", "Pragma": "no-cache"}});
     });
 
     it.skip("probes backend server until its online", async () => {

--- a/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
+++ b/frontend/src/pages/upgradePage/__tests__/UpgradePageContainer.test.tsx
@@ -136,6 +136,7 @@ describe("UpgradePageContainer", () => {
     getAvailableSpaceMock.mockRestore();
     axiosGetMock.mockResolvedValue("OK");
     restartWebPortalServiceMock.mockRestore();
+    server.close();
   });
 
   it("renders the correct banner image", async () => {
@@ -203,6 +204,8 @@ describe("UpgradePageContainer", () => {
         });
       });
     });
+
+    afterEach(() => server.close());
 
     it("renders prompt correctly", async () => {
       const { getByText, container: upgradePage } = mount();
@@ -709,7 +712,8 @@ describe("UpgradePageContainer", () => {
 
   describe("when updating web-portal succeeds", () => {
     beforeEach(async () => {
-      restartWebPortalServiceMock.mockResolvedValue("OK");
+      // we expect restartWebPortalService to fail since the backend server restarts
+      restartWebPortalServiceMock.mockRejectedValue(new Error("backend server restarted"));
       axiosGetMock.mockResolvedValue("OK");
 
       server = createServer();
@@ -742,121 +746,27 @@ describe("UpgradePageContainer", () => {
       });
     });
 
-    afterEach(() => {
-      jest.useRealTimers();
-      restartWebPortalServiceMock.mockRestore();
-      axiosGetMock.mockResolvedValue("OK");
-    })
+    afterEach(() => server.close());
 
-    it("renders prompt correctly", async () => {
-      const { getByText, container: upgradePage } = mount();
+    it("probes backend server to determine if its online", async () => {
+      const { queryByText, queryByTestId, getByText, container: upgradePage } = mount();
       await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
+
+      expect(queryByText(ErrorMessage.GenericError)).not.toBeInTheDocument();
+
+      await waitForElement(() => getByText("Update"));
+      expect(getByText("Update").parentElement).toBeDisabled();
 
       const prompt = upgradePage.querySelector(".prompt");
       expect(prompt).toMatchSnapshot();
-    });
-
-    it("renders the 'please wait' message while restarting web-portal service", async () => {
-      const { getByText } = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-    });
-
-    it("Update button is present", async () => {
-      const { getByText, queryByText } = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-
-      expect(queryByText("Update")).toBeInTheDocument();
-    });
-
-    it("Update button is disabled", async () => {
-      const { getByText } = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-
-      await waitForElement(() => getByText("Update"));
-      expect(getByText("Update").parentElement).toHaveProperty("disabled", true);
-    });
-
-    it("requests to restart the pt-os-web-portal systemd service", async () => {
-      const { getByText } = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-
-      expect(restartWebPortalServiceMock).toHaveBeenCalled();
-    });
-
-    it("doesn't display an error message when restartWebPortalService fails", async () => {
-      // we expect restartWebPortalService to fail since the backend server restarts
-      restartWebPortalServiceMock.mockRejectedValue(new Error("backend server restarted"));
-      const { getByText, queryByText} = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-      jest.useFakeTimers();
-      jest.runOnlyPendingTimers();
-
-      expect(queryByText(ErrorMessage.GenericError)).not.toBeInTheDocument();
-    });
-
-    it("renders a spinner while server is restarting", async () => {
-      const { getByText, container: upgradePage} = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-
-      expect(querySpinner(upgradePage)).toBeInTheDocument();
-    });
-
-    it("probes backend server to determine if its online", async () => {
-      jest.useFakeTimers();
-      const { getByText } = mount();
-      jest.runAllTimers();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-      jest.runOnlyPendingTimers();
-      jest.runOnlyPendingTimers();
-
-      expect(axios.get).toHaveBeenCalledWith(window.location.pathname + "?all", {"headers": {"Cache-Control": "no-cache", "Expires": "0", "Pragma": "no-cache"}});
-    });
-
-    it.skip("probes backend server until its online", async () => {
-      axiosGetMock.mockRejectedValue(new Error("I'm offline, try again later"));
-
-      jest.useFakeTimers();
-      const { getByText } = mount();
-      jest.runAllTimers();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-
-      expect(axios.get).not.toBeCalled();
-      jest.runOnlyPendingTimers();
-
-      // checks twice
-      jest.runOnlyPendingTimers();
-      expect(axios.get).toHaveBeenCalledTimes(1);
-      jest.runOnlyPendingTimers();
-      expect(axios.get).toHaveBeenCalledTimes(2);
-      // server is back online
-      axiosGetMock.mockResolvedValue("OK");
-      jest.runOnlyPendingTimers();
-      expect(axios.get).toHaveBeenCalledTimes(3);
-      await wait();
-      jest.runOnlyPendingTimers();
-      // we don't check again
-      expect(axios.get).toHaveBeenCalledTimes(3);
-    });
-
-    it("doesn't render the textarea component", async () => {
-      const { getByText, queryByTestId } = mount();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-      jest.useFakeTimers();
-      jest.runOnlyPendingTimers();
 
       expect(queryByTestId("textarea")).not.toBeInTheDocument();
+
+      expect(querySpinner(upgradePage)).toBeInTheDocument();
+
+      await wait(() => expect(window.location.replace).toHaveBeenCalled());
     });
 
-    it("refreshes window when server is restarted", async () => {
-      jest.useFakeTimers();
-      const { getByText } = mount();
-      jest.runAllTimers();
-      await waitForElement(() => getByText(UpgradePageExplanation.WaitingForServer))
-      jest.runOnlyPendingTimers();
-      jest.runOnlyPendingTimers();
-
-      expect(window.location.replace).toHaveBeenCalled();
-    });
   });
 
   describe("when updating web-portal fails", () => {
@@ -1365,6 +1275,7 @@ describe("UpgradePageContainer", () => {
       jest.useRealTimers();
       restartWebPortalServiceMock.mockRestore();
       axiosGetMock.mockResolvedValue("OK");
+      server.close();
     });
 
     it("renders prompt correctly", async () => {
@@ -1451,8 +1362,11 @@ describe("UpgradePageContainer", () => {
 
       fireEvent.click(getByText("Next"));
       await wait();
-      jest.runOnlyPendingTimers();
-      jest.runOnlyPendingTimers();
+      act(() => {
+        jest.runOnlyPendingTimers();
+        jest.runOnlyPendingTimers();
+      })
+      await wait();
       expect(restartWebPortalServiceMock).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
+++ b/frontend/src/pages/upgradePage/__tests__/__snapshots__/UpgradePageContainer.test.tsx.snap
@@ -839,7 +839,7 @@ exports[`UpgradePageContainer when updating web-portal fails renders prompt corr
 </h1>
 `;
 
-exports[`UpgradePageContainer when updating web-portal succeeds renders prompt correctly 1`] = `
+exports[`UpgradePageContainer when updating web-portal succeeds probes backend server to determine if its online 1`] = `
 <h1
   class="prompt"
 >


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1400) |


#### Main changes
- Ping 'next-page' instead of 'status' endpoint to determine when the server is back online.
- Check server socket is ready before refreshing.
- Don't use timers in tests associated with these changes to avoid issues. Combine several tests into only one.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
