### PR TITLE
Allow miniscreen takeover during onboarding

### DIFF
--- a/pt_os_web_portal/app.py
+++ b/pt_os_web_portal/app.py
@@ -1,5 +1,6 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from os import environ
 
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
@@ -46,6 +47,9 @@ class App:
         if state.get("app", "onboarded", fallback="false") == "false":
             logger.info("Onboarding not completed ...")
             if device == DeviceName.pi_top_4.value:
+                logger.debug("Setting ENV VAR to use miniscreen as system...")
+                environ["PT_MINISCREEN_SYSTEM"] = "1"
+
                 logger.info("Starting miniscreen onboarding application")
                 self.miniscreen_onboarding = OnboardingAssistantApp()
                 self.miniscreen_onboarding.start()

--- a/pt_os_web_portal/miniscreen_onboarding_assistant/onboarding_assistant_app.py
+++ b/pt_os_web_portal/miniscreen_onboarding_assistant/onboarding_assistant_app.py
@@ -10,12 +10,25 @@ logger = logging.getLogger(__name__)
 
 class OnboardingAssistantApp(BaseApp):
     def __init__(self):
+        self.user_has_control = False
         self.miniscreen = Pitop().miniscreen
 
         self.miniscreen.select_button.when_released = self.handle_select_button_release
         self.miniscreen.cancel_button.when_released = self.handle_cancel_button_release
         self.miniscreen.up_button.when_released = self.handle_up_button_release
         self.miniscreen.down_button.when_released = self.handle_down_button_release
+
+        def set_is_user_controlled(user_has_control) -> None:
+            self.user_has_control = user_has_control
+            if not user_has_control:
+                self._restore_miniscreen()
+
+            logger.info(
+                f"User has {'taken' if user_has_control else 'given back'} control of the miniscreen"
+            )
+
+        self.miniscreen.when_user_controlled = lambda: set_is_user_controlled(True)
+        self.miniscreen.when_system_controlled = lambda: set_is_user_controlled(False)
 
         super().__init__(
             display=self.miniscreen.device.display,
@@ -24,17 +37,25 @@ class OnboardingAssistantApp(BaseApp):
         )
 
     def handle_select_button_release(self):
-        self.root.handle_select_button()
+        if not self.user_has_control:
+            self.root.handle_select_button()
 
     def handle_cancel_button_release(self):
-        self.root.switch_menu()
+        if not self.user_has_control:
+            self.root.switch_menu()
 
     def handle_up_button_release(self):
-        self.root.scroll_up()
+        if not self.user_has_control:
+            self.root.scroll_up()
 
     def handle_down_button_release(self):
-        self.root.scroll_down()
+        if not self.user_has_control:
+            self.root.scroll_down()
 
-    @property
-    def user_has_control(self) -> bool:
-        return self.miniscreen.is_active
+    def _restore_miniscreen(self):
+        try:
+            self.miniscreen.reset()
+        except RuntimeError as e:
+            logger.error(f"Error resetting miniscreen: {e}")
+
+        self.display()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-157) |


#### Main changes
- Run onboarding miniscreen app as system to allow takeover during onboarding process.
- When user gives back control of the miniscreen, reset miniscreen and re-display app.
- Don't handle button presses if user has control.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
