### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -48,7 +48,7 @@ jobs:
       - run: cp frontend/yarn.lock .
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
           cache: 'yarn'

--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -7,10 +7,10 @@ jobs:
    runs-on: ubuntu-20.04
    steps:
      - name: Checkout code
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
 
      - name: Setup Python
-       uses: actions/setup-python@v4
+       uses: actions/setup-python@v5
        with:
          python-version: 3.11
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Workaround: At the moment, only lock files in the project root are
       # supported...

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,7 @@ def _patch_modules():
         "pt_web_vnc",
         "pt_web_vnc.vnc",
         "nmcli",
+        "gevent",
     ]
     for module in modules_to_patch:
         modules[module] = Mock()

--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,8 @@ def _patch_modules():
         "pt_web_vnc.vnc",
         "nmcli",
         "gevent",
+        "zmq",
+        "zmq.green",
     ]
     for module in modules_to_patch:
         modules[module] = Mock()

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -16,3 +16,4 @@ pitop.camera python3-pitop-camera
 pitop.common python3-pitop-common
 pitop.robotics python3-pitop-robotics
 pitop.system python3-pitop-system
+pyzmq python3-zmq; PEP386

--- a/frontend/src/components/onboarding_app/App.tsx
+++ b/frontend/src/components/onboarding_app/App.tsx
@@ -29,6 +29,7 @@ export default () => {
   const [email, setEmail] = useState("");
   const [connectedNetwork, setConnectedNetwork] = useState<Network>();
   const [skipUpgradePage, setSkipUpgradePage] = useState(false);
+  const [enableDisconnectedFromApDialog, setEnableDisconnectedFromApDialog] = useState(true);
 
   useEffect(() => {
     getBuildInfo()
@@ -147,6 +148,7 @@ export default () => {
                 history.push(PageRoute.Registration);
                 window.location.reload();
               }}
+              setEnableDisconnectedFromApDialog={setEnableDisconnectedFromApDialog}
             />
           )}
         />
@@ -182,7 +184,7 @@ export default () => {
         <Route component={ErrorPage} />
       </Switch>
       <BuildInformation info={buildInfo} className={styles.buildInfo} />
-      <HotspotDisconnectDialog enabled={useLocation().pathname !== PageRoute.Restart} />
+      <HotspotDisconnectDialog enabled={useLocation().pathname !== PageRoute.Restart && enableDisconnectedFromApDialog} />
     </>
   );
 };

--- a/frontend/src/components/onboarding_app/__tests__/App.test.tsx
+++ b/frontend/src/components/onboarding_app/__tests__/App.test.tsx
@@ -36,11 +36,7 @@ import getCurrentKeyboard from "../../../services/getCurrentKeyboard";
 import setKeyboard from "../../../services/setKeyboard";
 import setRegistration from "../../../services/setRegistration";
 import getAvailableSpace from "../../../services/getAvailableSpace";
-
-import getNetworks from "../../../services/getNetworks";
 import isConnectedToNetwork from "../../../services/isConnectedToNetwork";
-import connectToNetwork from "../../../services/connectToNetwork";
-
 import serverStatus from "../../../services/serverStatus";
 import restartWebPortalService from "../../../services/restartWebPortalService";
 import isConnectedThroughAp from "../../../services/isConnectedThroughAp";
@@ -49,9 +45,7 @@ import { UpgradePageExplanation } from "../../../pages/upgradePage/UpgradePage";
 import { waitFor } from "../../../../test/helpers/waitFor";
 import wsBaseUrl from "../../../services/wsBaseUrl";
 
-jest.mock("../../../services/getNetworks");
 jest.mock("../../../services/isConnectedToNetwork");
-jest.mock("../../../services/connectToNetwork");
 jest.mock("../../../services/getBuildInfo");
 jest.mock("../../../services/getLocales");
 jest.mock("../../../services/getCurrentLocale");
@@ -87,9 +81,7 @@ const getCurrentTimezoneMock = getCurrentTimezone as jest.Mock;
 const setCountryMock = setCountry as jest.Mock;
 const setCurrentTimezone = setTimezone as jest.Mock;
 const setRegistrationMock = setRegistration as jest.Mock;
-const getNetworksMock = getNetworks as jest.Mock;
 const isConnectedToNetworkMock = isConnectedToNetwork as jest.Mock;
-const connectToNetworkMock = connectToNetwork as jest.Mock;
 const getAvailableSpaceMock = getAvailableSpace as jest.Mock;
 const serverStatusMock = serverStatus as jest.Mock;
 const restartWebPortalServiceMock = restartWebPortalService as jest.Mock;
@@ -215,15 +207,7 @@ describe("App", () => {
     currentKeyboardMock.mockResolvedValue({ layout: "us" });
     setKeyboardMock.mockResolvedValue("OK");
     setRegistrationMock.mockResolvedValue("OK");
-    getNetworksMock.mockResolvedValue([
-      {
-        ssid: "wifi network",
-        bssid: "wifi network bssid",
-        passwordRequired: false,
-      },
-    ]);
     isConnectedToNetworkMock.mockResolvedValue({ connected: true });
-    connectToNetworkMock.mockResolvedValue("OK");
     isConnectedThroughApMock.mockResolvedValue({ isUsingAp: false });
 
     // upgrade page mocks
@@ -637,14 +621,14 @@ describe("App", () => {
           queryReactSelect,
         } = mount(PageRoute.Wifi);
         await waitForWifiPage();
-
+        await waitFor(() => expect(getByText("Please select WiFi network...")).toBeInTheDocument());
         fireEvent.keyDown(queryReactSelect()!, {
           keyCode: KeyCode.DownArrow,
         });
-        fireEvent.click(getByText("wifi network"));
 
+        fireEvent.click(getByText("Depto 606"));
         fireEvent.click(getByText("Join"));
-        await waitForElement(() => getByText("OK"));
+        await waitFor(() => expect(getByText("OK")).toBeInTheDocument());
         fireEvent.click(getByText("OK"));
 
         await waitForUpgradePage();

--- a/frontend/src/components/onboarding_app/__tests__/App.test.tsx
+++ b/frontend/src/components/onboarding_app/__tests__/App.test.tsx
@@ -302,8 +302,8 @@ describe("App", () => {
         expect(getByTestId("reconnect-ap-dialog")).toHaveClass("hidden");
 
         serverStatusMock.mockRejectedValue("Error");
-        // Advance time to wait for 5 failed requests for dialog to appear
-        jest.advanceTimersByTime(6_000);
+        // Advance time to wait for 3 failed requests for dialog to appear
+        jest.advanceTimersByTime(11_000);
         jest.useRealTimers();
         await waitFor(() =>
           expect(getByTestId("reconnect-ap-dialog")).not.toHaveClass("hidden")
@@ -347,7 +347,7 @@ describe("App", () => {
     await checkForDialog();
     fireEvent.click(getByText("Agree"));
 
-    // on terms page
+    // on wifi page
     await waitForWifiPage();
     await checkForDialog();
     fireEvent.click(getByText("Next"));

--- a/frontend/src/msw/handlers.ts
+++ b/frontend/src/msw/handlers.ts
@@ -60,6 +60,9 @@ export default [
   rest.get("/current-wifi-bssid", (_, res, ctx) => {
     return res(ctx.json(connectedNetwork?.bssid || ""));
   }),
+  rest.get("/current-wifi-ssid", (_, res, ctx) => {
+    return res(ctx.json(connectedNetwork?.ssid || ""));
+  }),
   rest.post<{ bssid: string; password: string }>(
     "/wifi-credentials",
     (req, res, ctx) => {

--- a/frontend/src/pages/hotspotDisconnectDialog/HotspotDisconnectDialog.tsx
+++ b/frontend/src/pages/hotspotDisconnectDialog/HotspotDisconnectDialog.tsx
@@ -12,12 +12,18 @@ export type Props = {
 
 export default ({ enabled = true }: Props) => {
   const [disconnectedFromAp, setDisconnectedFromAp] = useState(false);
+  const [requestFailures, setRequestFailures] = useState(0);
+  const MAX_DISCONNECT_REQUESTS = 5;
 
   // preload 'connect-to-wifi' image since it can't be loaded when it is shown
   useEffect(() => {
     const image = new Image();
     image.src = connectToWifiImage;
   }, []);
+
+  useEffect(() => {
+    setDisconnectedFromAp(requestFailures >= MAX_DISCONNECT_REQUESTS);
+  }, [requestFailures]);
 
   useEffect(() => {
     // when connected to the pi-top hotspot, monitor disconnections
@@ -29,12 +35,12 @@ export default ({ enabled = true }: Props) => {
 
         setInterval(async () => {
           serverStatus({ timeout: 1000 })
-            .then(() => setDisconnectedFromAp(false))
-            .catch(() => setDisconnectedFromAp(true));
+            .then(() => setRequestFailures(0))
+            .catch(() => setRequestFailures(prevCount => prevCount + 1));
         }, 1000);
       })
       .catch(() => null);
-  }, [setDisconnectedFromAp]);
+  }, [setDisconnectedFromAp, setRequestFailures]);
 
   return (
     <Dialog

--- a/frontend/src/pages/hotspotDisconnectDialog/HotspotDisconnectDialog.tsx
+++ b/frontend/src/pages/hotspotDisconnectDialog/HotspotDisconnectDialog.tsx
@@ -13,7 +13,7 @@ export type Props = {
 export default ({ enabled = true }: Props) => {
   const [disconnectedFromAp, setDisconnectedFromAp] = useState(false);
   const [requestFailures, setRequestFailures] = useState(0);
-  const MAX_DISCONNECT_REQUESTS = 5;
+  const MAX_DISCONNECT_REQUESTS = 3;
 
   // preload 'connect-to-wifi' image since it can't be loaded when it is shown
   useEffect(() => {
@@ -26,6 +26,10 @@ export default ({ enabled = true }: Props) => {
   }, [requestFailures]);
 
   useEffect(() => {
+    setRequestFailures(0);
+  }, [enabled]);
+
+  useEffect(() => {
     // when connected to the pi-top hotspot, monitor disconnections
     isConnectedThroughAp()
       .then((connectedViaAp) => {
@@ -34,10 +38,10 @@ export default ({ enabled = true }: Props) => {
         }
 
         setInterval(async () => {
-          serverStatus({ timeout: 1000 })
+          serverStatus({ timeout: 7000 })
             .then(() => setRequestFailures(0))
             .catch(() => setRequestFailures(prevCount => prevCount + 1));
-        }, 1000);
+        }, 2000);
       })
       .catch(() => null);
   }, [setDisconnectedFromAp, setRequestFailures]);

--- a/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
+++ b/frontend/src/pages/upgradePage/UpgradePageContainer.tsx
@@ -101,9 +101,10 @@ export type Props = {
   goToPreviousPage?: () => void;
   hideSkip?: boolean;
   isCompleted?: boolean;
+  setEnableDisconnectedFromApDialog?: (enable: boolean) => void;
 };
 
-export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props) => {
+export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted, setEnableDisconnectedFromApDialog }: Props) => {
   const [message, setMessage] = useState<OSUpdaterMessage>();
   const [isOpen, setIsOpen] = useState(false);
   document.title = "pi-topOS System Update"
@@ -325,6 +326,8 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props
     ) {
       if (checkingWebPortalRef.current) {
         setState(UpdateState.WaitingForServer);
+        // stop checking for hotspot disconnections while the service restarts
+        setEnableDisconnectedFromApDialog && setEnableDisconnectedFromApDialog(false)
         restartWebPortalService()
           .catch(() => setError(ErrorType.None)) // ignored, request will fail since backend server is restarted
           .finally(() => setTimeout(waitUntilServerIsOnline, 300));
@@ -358,9 +361,18 @@ export default ({ goToNextPage, goToPreviousPage, hideSkip, isCompleted }: Props
 
   return (
     <UpgradePage
-      onNextClick={goToNextPage}
-      onSkipClick={goToNextPage}
-      onBackClick={goToPreviousPage}
+      onNextClick={() => {
+        setEnableDisconnectedFromApDialog && setEnableDisconnectedFromApDialog(true);
+        goToNextPage && goToNextPage()
+      }}
+      onSkipClick={() => {
+        setEnableDisconnectedFromApDialog && setEnableDisconnectedFromApDialog(true);
+        goToNextPage && goToNextPage()
+      }}
+      onBackClick={() => {
+        setEnableDisconnectedFromApDialog && setEnableDisconnectedFromApDialog(true);
+        goToPreviousPage && goToPreviousPage()
+      }}
       hideSkip={hideSkip}
       onStartUpgradeClick={() => {
         if (isOpen) {

--- a/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
+++ b/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
@@ -60,6 +60,10 @@ describe("StandaloneWifiPageContainer", () => {
     mount = () => render(<StandaloneWifiPageContainer />);
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("renders spinner while loading", async () => {
     const { container: standaloneWifiPageContainer } = mount();
 
@@ -523,7 +527,8 @@ describe("StandaloneWifiPageContainer", () => {
   });
 
   it("when using AP mode, displays reconnect to AP dialog", async () => {
-    jest.setTimeout(30_000);
+    jest.useFakeTimers();
+    jest.setTimeout(10_000);
     isConnectedThroughApMock.mockResolvedValue({ isUsingAp: true });
 
     const { getByTestId } = mount();
@@ -532,14 +537,21 @@ describe("StandaloneWifiPageContainer", () => {
       expect(getByTestId("reconnect-ap-dialog")).toHaveClass("hidden");
 
       serverStatusMock.mockRejectedValue("Error");
+      // Advance time to wait for 5 failed requests for dialog to appear
+      jest.advanceTimersByTime(6_000);
+      jest.useRealTimers();
       await waitFor(() =>
         expect(getByTestId("reconnect-ap-dialog")).not.toHaveClass("hidden")
-      );
+      , {timeout: 10_000});
 
       serverStatusMock.mockResolvedValue("OK");
+      // Advance time and wait for dialog to dissapear
+      jest.useFakeTimers();
+      jest.advanceTimersByTime(1_000);
+      jest.useRealTimers();
       await waitFor(() =>
         expect(getByTestId("reconnect-ap-dialog")).toHaveClass("hidden")
-      );
+      , {timeout: 10_000});
     });
   });
 });

--- a/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
+++ b/frontend/src/pages/wifiPage/__tests__/StandaloneWifiPageContainer.test.tsx
@@ -343,7 +343,7 @@ describe("StandaloneWifiPageContainer", () => {
 
   it("renders error when incorrect password is used to connect to network", async () => {
     const network = networks.find(({ passwordRequired }) => passwordRequired)!;
-
+    jest.useFakeTimers();
     mount();
 
     await waitForElementToBeRemoved(() =>
@@ -367,6 +367,8 @@ describe("StandaloneWifiPageContainer", () => {
     // join network
     fireEvent.click(screen.getByText("Join"));
 
+    jest.advanceTimersByTime(35_000);
+    // jest.useRealTimers();
     expect(
       await screen.findByText(
         `There was an error connecting to ${network.ssid}... please check your password and try again`
@@ -376,6 +378,7 @@ describe("StandaloneWifiPageContainer", () => {
 
   it("clears incorrect password error when cancel is clicked and new network selected", async () => {
     const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+    jest.useFakeTimers();
 
     mount();
 
@@ -399,6 +402,8 @@ describe("StandaloneWifiPageContainer", () => {
 
     // join network
     fireEvent.click(screen.getByText("Join"));
+
+    jest.advanceTimersByTime(35_000);
 
     expect(
       await screen.findByText(
@@ -424,6 +429,7 @@ describe("StandaloneWifiPageContainer", () => {
 
   it("clears incorrect password error when retry is clicked", async () => {
     const network = networks.find(({ passwordRequired }) => passwordRequired)!;
+    jest.useFakeTimers();
 
     mount();
 
@@ -448,6 +454,8 @@ describe("StandaloneWifiPageContainer", () => {
     // join network
     fireEvent.click(screen.getByText("Join"));
 
+    jest.advanceTimersByTime(35_000);
+
     expect(
       await screen.findByText(
         `There was an error connecting to ${network.ssid}... please check your password and try again`
@@ -459,6 +467,8 @@ describe("StandaloneWifiPageContainer", () => {
       target: { value: "correct-password" },
     });
     fireEvent.click(screen.getByText("Retry"));
+
+    jest.advanceTimersByTime(1_000);
 
     // it hides the error as soon as retry button is clicked
     expect(
@@ -472,6 +482,9 @@ describe("StandaloneWifiPageContainer", () => {
         return res(ctx.json(network.bssid));
       })
     );
+
+    jest.advanceTimersByTime(1_000);
+
     // retried request succeeds
     expect(
       await screen.findByText(/Great, your pi-top is connected/)

--- a/frontend/src/pages/wifiPage/__tests__/WifiPageContainer.test.tsx
+++ b/frontend/src/pages/wifiPage/__tests__/WifiPageContainer.test.tsx
@@ -370,6 +370,7 @@ describe("WifiPageContainer", () => {
   });
 
   it("renders error when incorrect password is used to connect to network", async () => {
+    jest.useFakeTimers();
     const network = networks.find(({ passwordRequired }) => passwordRequired)!;
 
     mount();
@@ -394,6 +395,8 @@ describe("WifiPageContainer", () => {
 
     // join network
     fireEvent.click(screen.getByText("Join"));
+
+    jest.advanceTimersByTime(35_000);
 
     expect(
       await screen.findByText(
@@ -403,6 +406,7 @@ describe("WifiPageContainer", () => {
   });
 
   it("clears incorrect password error when cancel is clicked and new network selected", async () => {
+    jest.useFakeTimers()
     const network = networks.find(({ passwordRequired }) => passwordRequired)!;
 
     mount();
@@ -427,6 +431,8 @@ describe("WifiPageContainer", () => {
 
     // join network
     fireEvent.click(screen.getByText("Join"));
+
+    jest.advanceTimersByTime(35_000);
 
     expect(
       await screen.findByText(
@@ -451,6 +457,7 @@ describe("WifiPageContainer", () => {
   });
 
   it("clears incorrect password error when retry is clicked", async () => {
+    jest.useFakeTimers();
     server.use(
       rest.get("/current-wifi-bssid", (_, res, ctx) => {
         return res(ctx.json(""));
@@ -482,6 +489,8 @@ describe("WifiPageContainer", () => {
     // join network
     fireEvent.click(screen.getByText("Join"));
 
+    jest.advanceTimersByTime(35_000);
+
     expect(
       await screen.findByText(
         `There was an error connecting to ${network.ssid}... please check your password and try again`
@@ -493,6 +502,8 @@ describe("WifiPageContainer", () => {
       target: { value: "correct-password" },
     });
     fireEvent.click(screen.getByText("Retry"));
+
+    jest.advanceTimersByTime(1_000);
 
     // it hides the error as soon as retry button is clicked
     expect(
@@ -507,6 +518,8 @@ describe("WifiPageContainer", () => {
         return res(ctx.json(network.bssid));
       })
     );
+
+    jest.advanceTimersByTime(5_000);
 
     // retried request succeeds
     expect(

--- a/frontend/src/pages/wifiPage/connectDialog/ConnectDialogContainer.tsx
+++ b/frontend/src/pages/wifiPage/connectDialog/ConnectDialogContainer.tsx
@@ -4,6 +4,7 @@ import ConnectDialog from "./ConnectDialog";
 
 import connectToNetwork from "../../../services/connectToNetwork";
 import connectedBSSID from "../../../services/connectedBSSID";
+import connectedSSID from "../../../services/connectedSSID";
 
 import { Network } from "../../../types/Network";
 
@@ -33,51 +34,67 @@ export default ({ setConnectedNetwork, ...props }: Props) => {
     setIsConnected(false);
   }, [props.network]);
 
-  const requestTimeoutMs = 1500;
-  const requestIntervalMs = 500;
+  const requestTimeoutMs = 2000;
+  const requestIntervalMs = 1000;
+  let elapsedWaitingTimeMs = useRef(0);
+
+  const onConnection = useCallback((network: Network) => {
+    clearCheckConnectionInterval();
+    setIsConnected(true);
+    setIsConnecting(false);
+    setConnectError(false);
+    setConnectedNetwork(network);
+  }, [setConnectError, setConnectedNetwork, setIsConnecting]);
 
   const checkConnection = useCallback((network: Network) => {
     if (checkConnectionInterval.current) {
       return ;
     }
+    elapsedWaitingTimeMs.current = 0;
     checkConnectionInterval.current = setInterval(async () => {
+      if (elapsedWaitingTimeMs.current > 30_000) {
+        // failed to connect, display dialog with error message
+        setConnectError(true);
+        setIsConnecting(false);
+      } else {
+        elapsedWaitingTimeMs.current += requestIntervalMs;
+      }
+
+      // check for BSSID
       await connectedBSSID(requestTimeoutMs)
         .then((bssid) => {
-          const connectedToBssid = bssid === network.bssid;
-          setIsConnected(connectedToBssid);
-          if (connectedToBssid) {
-            setConnectError(false);
-            setConnectedNetwork(network);
-            clearCheckConnectionInterval();
+          if (bssid === network.bssid) {
+            onConnection(network);
           }
         })
         .catch ((_) => {})
+
+      // check for SSID
+      await connectedSSID(requestTimeoutMs)
+        .then((ssid) => {
+          if (ssid === network.ssid) {
+            onConnection(network);
+          }
+        })
+        .catch ((_) => {})
+
     }, requestIntervalMs);
-  }, [setConnectedNetwork, setConnectError]);
+  }, [setConnectError, setIsConnecting, onConnection]);
 
   const connect = useCallback(
     (network: Network, password: string) => {
+      clearCheckConnectionInterval();
       setIsConnecting(true);
       setIsConnected(false);
       setConnectError(false);
 
-      // check in the background if connection succeeded.
-      // even if 'connectToNetwork' fails, the pi-top might have connected to the network
-      // this could happen when the client disconnects from the pi-top hotpot
+      // check in the background if connection succeeded and update state
       checkConnection(network);
 
       connectToNetwork({ bssid: network.bssid, password: password }, 30000)
-        .then(() => {
-          // do nothing, 'checkConnection' handles state
-        })
-        .catch(() => {
-          setConnectError(true);
-        })
-        .finally(() => {
-          setIsConnecting(false);
-        });
+        .catch(() => {})
     },
-    [setConnectedNetwork, checkConnection]
+    [checkConnection]
   );
 
   return (

--- a/frontend/src/pages/wifiPage/connectDialog/ConnectDialogContainer.tsx
+++ b/frontend/src/pages/wifiPage/connectDialog/ConnectDialogContainer.tsx
@@ -39,9 +39,8 @@ export default ({ setConnectedNetwork, ...props }: Props) => {
     }
     setConnectivityCheckInterval(setInterval(async () => {
       try {
-        let connectedToBssid = false;
         await connectedBSSID(requestTimeoutMs).then((bssid) => {
-          connectedToBssid = bssid === network.bssid;
+          const connectedToBssid = bssid === network.bssid;
           setIsConnected(connectedToBssid);
           if (connectedToBssid) {
             setConnectError(false);

--- a/frontend/src/services/connectedSSID.ts
+++ b/frontend/src/services/connectedSSID.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+
+import apiBaseUrl from "./apiBaseUrl";
+
+export default async function connectedBSSID(timeout?: number) {
+  const { data } = await axios.get<string>(
+    `${apiBaseUrl}/current-wifi-ssid`,
+    { timeout: timeout || 5000 }
+  );
+
+  return data;
+}

--- a/pt_os_web_portal/__init__.py
+++ b/pt_os_web_portal/__init__.py
@@ -1,1 +1,5 @@
+from gevent import monkey
+
 from .version import __version__
+
+monkey.patch_all()

--- a/pt_os_web_portal/__init__.py
+++ b/pt_os_web_portal/__init__.py
@@ -1,5 +1,9 @@
+import pitop.common.ptdm
+import zmq.green
 from gevent import monkey
 
 from .version import __version__
 
 monkey.patch_all()
+# Use zmq.green for gevent compatibility
+pitop.common.ptdm.zmq = zmq.green

--- a/pt_os_web_portal/backend/helpers/wifi.py
+++ b/pt_os_web_portal/backend/helpers/wifi.py
@@ -35,3 +35,8 @@ def attempt_connection(bssid: str, password: str, on_connection=None) -> None:
 def current_wifi_bssid() -> str:
     logger.info("Attempting to determine to which bSSID we're connected to")
     return get_wifi_manager_instance().bssid_connected()
+
+
+def current_wifi_ssid() -> str:
+    logger.info("Attempting to determine to which SSID we're connected to")
+    return get_wifi_manager_instance().ssid_connected()

--- a/pt_os_web_portal/backend/helpers/wifi_connection/manager.py
+++ b/pt_os_web_portal/backend/helpers/wifi_connection/manager.py
@@ -45,3 +45,6 @@ class WifiManager:
 
     def get_formatted_ssids(self):
         return self.handler.get_formatted_ssids()
+
+    def ssid_connected(self) -> str:
+        return self.handler.ssid_connected()

--- a/pt_os_web_portal/backend/helpers/wifi_connection/network_manager_handler.py
+++ b/pt_os_web_portal/backend/helpers/wifi_connection/network_manager_handler.py
@@ -96,8 +96,6 @@ class NetworkManagerHandler:
 
     def bssid_connected(self) -> str:
         try:
-            if not self.is_connected():
-                return ""
             for connection in nmcli.device.wifi(ifname=self.ifname, rescan=False):
                 if connection.in_use:
                     return connection.bssid

--- a/pt_os_web_portal/backend/helpers/wifi_connection/wpa_supplicant_handler.py
+++ b/pt_os_web_portal/backend/helpers/wifi_connection/wpa_supplicant_handler.py
@@ -195,3 +195,19 @@ class WpaSupplicantHandler:
             }
             for r in self.scan_and_get_results()
         ]
+
+    def ssid_connected(self) -> str:
+        try:
+            if self.get_status() != IfaceStatus.CONNECTED:
+                return ""
+
+            # query the network to wpa_cli
+            response = self.wifi_interface._wifi_ctrl._send_cmd_to_wpas(
+                self.ifname, "STATUS", True
+            )
+            for line in response.split("\n"):
+                if line.startswith("ssid="):
+                    return line.replace("ssid=", "")
+        except Exception:
+            pass
+        return ""

--- a/pt_os_web_portal/backend/routes.py
+++ b/pt_os_web_portal/backend/routes.py
@@ -71,7 +71,12 @@ from .helpers.system import (
 from .helpers.timezone import get_all_timezones, get_current_timezone, set_timezone
 from .helpers.vnc import PtWebVncDisplayId
 from .helpers.vnc_advanced_wifi_gui import get_advanced_wifi_gui_url
-from .helpers.wifi import attempt_connection, current_wifi_bssid, get_ssids
+from .helpers.wifi import (
+    attempt_connection,
+    current_wifi_bssid,
+    current_wifi_ssid,
+    get_ssids,
+)
 from .helpers.wifi_country import (
     current_wifi_country,
     list_wifi_countries,
@@ -273,6 +278,12 @@ def get_is_connected():
 def get_is_connected_to_bssid():
     logger.debug("Route '/current-wifi-bssid'")
     return jdumps(current_wifi_bssid())
+
+
+@app.route("/current-wifi-ssid", methods=["GET"])
+def get_is_connected_to_ssid():
+    logger.debug("Route '/current-wifi-ssid'")
+    return jdumps(current_wifi_ssid())
 
 
 @app.route("/is-connected-through-ap", methods=["GET"])

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     requests>=2.25.1
     websockets>=8.1
     nmcli>=1.3.0
+    pyzmq>=20.0.0,<25.0.0
 include_package_data = True
 
 [options.entry_points]

--- a/tests/test_network_manager_handler_class.py
+++ b/tests/test_network_manager_handler_class.py
@@ -111,7 +111,7 @@ def test_connect_failure_on_invalid_bssid(network_manager_handler):
     assert handler.is_connected() is False
 
 
-def test_connect_excepts_on_failure(network_manager_handler, mocker, nmcli_mock):
+def test_connect_doesnt_except_on_failure(network_manager_handler, mocker, nmcli_mock):
     mocker.patch.object(
         nmcli_mock.device,
         "wifi_connect",
@@ -119,8 +119,7 @@ def test_connect_excepts_on_failure(network_manager_handler, mocker, nmcli_mock)
     )
     handler = network_manager_handler()
 
-    with pytest.raises(Exception):
-        handler.connect(bssid="F0:9B:B8:2D:20:4C", password="valid-password")
+    handler.connect(bssid="F0:9B:B8:2D:20:4C", password="valid-password")
 
 
 def test_bssid_connected_function_output(network_manager_handler):


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
- Monkey patch python standard library for `gevent`. This allows the backend to handle multiple requests, which became an issue once we started using the `/status` endpoint regularly at the same time as long blocking operations (eg: connecting to wi-fi). **This requires that we also patch the SDK's `zmq` module and change it to `zmq.green` which is compatible with `gevent`**.
- Display hotspot disconnection dialog after 5 failures. This avoids rapidly displaying/hiding the 'disconnected from ap' dialog when 1 request fails but the connection is still active.
- fix: clear check-connection interval on success. 

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
