### PR TITLE
Mock std library on web-portal main script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       args: ["--profile", "black"]
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
     - id: black
 
@@ -26,14 +26,14 @@ repos:
     - id: autopep8
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
     - id: flake8
       name: flake8
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
-    hooks:
-    -   id: mypy
-        additional_dependencies: [types-all]
-        args: ["--ignore-missing-imports", "--install-types", "--non-interactive"]
+# -   repo: https://github.com/pre-commit/mirrors-mypy
+#     rev: v1.11.1
+#     hooks:
+#     -   id: mypy
+#         additional_dependencies: [types-all]
+#         args: ["--install-types", "--non-interactive"]

--- a/debian/pt-os-web-portal.install
+++ b/debian/pt-os-web-portal.install
@@ -1,1 +1,2 @@
 pt_os_web_portal/rover_controller/pt-os-web-portal-rover-controller       /usr/bin/
+pt_os_web_portal/pt-os-web-portal                                         /usr/bin/

--- a/pt_os_web_portal/__init__.py
+++ b/pt_os_web_portal/__init__.py
@@ -1,11 +1,1 @@
-from gevent import monkey
-
-monkey.patch_all()
-
-import pitop.common.ptdm  # noqa: E402
-import zmq.green  # noqa: E402
-
 from .version import __version__  # noqa: E402
-
-# Use zmq.green for gevent compatibility
-pitop.common.ptdm.zmq = zmq.green

--- a/pt_os_web_portal/pt-os-web-portal
+++ b/pt_os_web_portal/pt-os-web-portal
@@ -1,13 +1,24 @@
-import logging
-from os import geteuid
-from signal import SIGINT, SIGTERM
-from sys import exit
+#!/usr/bin/env python3
+from gevent import monkey
 
-import click
-import click_logging
-from gevent import signal_handler, wait
+monkey.patch_all()
 
-from .app import App
+import pitop.common.ptdm  # noqa: E402
+import zmq.green  # noqa: E402
+
+# Use zmq.green for gevent compatibility
+pitop.common.ptdm.zmq = zmq.green
+
+import logging  # noqa: E402
+from os import geteuid  # noqa: E402
+from signal import SIGINT, SIGTERM  # noqa: E402
+from sys import exit  # noqa: E402
+
+import click  # noqa: E402
+import click_logging  # noqa: E402
+from gevent import signal_handler, wait  # noqa: E402
+
+from pt_os_web_portal.app import App  # noqa: E402
 
 logger = logging.getLogger()
 click_logging.basic_config(logger)

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ include_package_data = True
 
 [options.entry_points]
 console_scripts =
-    pt-os-web-portal=pt_os_web_portal.__main__:main
+    ; pt-os-web-portal=pt_os_web_portal.__main__:main
     pt-os-web-portal-frontend=pt_os_web_portal.app_window.__main__:main
     ; pt-os-web-portal-rover-controller=pt_os_web_portal.rover_controller.__main__:main
     pt-os-web-portal-vnc-advanced-wifi=pt_os_web_portal.backend.helpers.vnc_advanced_wifi_gui:main


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
Stop using `console-scripts` in `setup.cfg` to set the entry point of the app. Since the standard library needs to be patched for `gevent`, we needed to do it on the `__init__.py` file in the main module. However, since the web-portal module is imported by other modules (eg: `pi-top-usb-setup`), the standard library was mocked for those too, which caused issues.

By changing how the entry-point for the app is setup, we can patch the std library in that particular file instead of doing it on a module-level; the main script used to start the app is now installed using the Debian install file.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
