### PR TITLE
Don't restart networking services on system upgrade

### DIFF
--- a/debian/extra/handle-service-restart-in-policy
+++ b/debian/extra/handle-service-restart-in-policy
@@ -1,0 +1,119 @@
+#!/bin/bash
+###############################################################
+#                Unofficial 'Bash strict mode'                #
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/  #
+###############################################################
+set -euo pipefail
+IFS=$'\n\t'
+###############################################################
+
+POLICY_FILE="/usr/sbin/policy-rc.d"
+
+check_root() {
+    if [ "$EUID" -ne 0 ]; then
+        echo "Please run as root"
+        return 1
+    fi
+    return 0
+}
+
+validate_args() {
+    local command="$1"
+    local service_name="$2"
+
+    if [ -z "$command" ] || [ -z "$service_name" ]; then
+        echo "Please provide both command and service name"
+        echo "Usage: $0 <add|remove> <service-name>"
+        return 1
+    fi
+
+    if [ "$command" != "add" ] && [ "$command" != "remove" ]; then
+        echo "Invalid command. Use 'add' or 'remove'"
+        return 1
+    fi
+    return 0
+}
+
+init_policy_file() {
+    if [ ! -f "$POLICY_FILE" ]; then
+        echo '#!/bin/sh' > "$POLICY_FILE"
+        echo '' >> "$POLICY_FILE"
+    fi
+}
+
+is_service_in_policy() {
+    local service_name="$1"
+    grep -q "if \[ \"\$1\" = \"$service_name\"" "$POLICY_FILE"
+    return $?
+}
+
+add_service_to_policy() {
+    local service_name="$1"
+
+    if is_service_in_policy "$service_name"; then
+        echo "Service $service_name already in policy - skipping ..."
+        return 0
+    fi
+
+    if grep -q "exit 0" "$POLICY_FILE"; then
+        # Insert before exit 0
+        sed -i "\$i\\if [ \"\$1\" = \"$service_name\" ]; then\\n    exit 101\\nfi\\n" "$POLICY_FILE"
+    else
+        # Append to file
+        echo "if [ \"\$1\" = \"$service_name\" ]; then" >> "$POLICY_FILE"
+        echo "echo \"Skipping $service_name restart...\" 1>&2" >> "$POLICY_FILE"
+        echo "    exit 101" >> "$POLICY_FILE"
+        echo "fi" >> "$POLICY_FILE"
+        echo "" >> "$POLICY_FILE"
+        echo "exit 0" >> "$POLICY_FILE"
+    fi
+    echo "Policy added for $service_name into $POLICY_FILE"
+}
+
+remove_service_from_policy() {
+    local service_name="$1"
+
+    if ! is_service_in_policy "$service_name"; then
+        echo "Service $service_name not found in policy - skipping ..."
+        return 0
+    fi
+
+    # Remove the service entry
+    sed -i "/if \[ \"\$1\" = \"$service_name\" ]/,+3d" "$POLICY_FILE"
+    # Remove any extra blank lines
+    sed -i '/^$/N;/^\n$/D' "$POLICY_FILE"
+    # Ensure file ends with exit 0 if not empty
+    if [ -s "$POLICY_FILE" ] && ! grep -q "exit 0" "$POLICY_FILE"; then
+        echo "" >> "$POLICY_FILE"
+        echo "exit 0" >> "$POLICY_FILE"
+    fi
+    echo "Policy removed for $service_name from $POLICY_FILE"
+}
+
+set_policy_permissions() {
+    chmod 755 "$POLICY_FILE"
+    chown root:root "$POLICY_FILE"
+}
+
+handle_service_policy() {
+    local command="$1"
+    local service_name="$2"
+
+    check_root || return 1
+    validate_args "$command" "$service_name" || return 1
+
+    if [ "$command" = "add" ]; then
+        init_policy_file
+        add_service_to_policy "$service_name"
+    else
+        [ ! -f "$POLICY_FILE" ] && {
+            echo "Policy file does not exist, nothing to remove"
+            return 0
+        }
+        remove_service_from_policy "$service_name"
+    fi
+
+    set_policy_permissions
+}
+
+handle_service_policy "$1" "$2"

--- a/debian/extra/handle-service-restart-in-policy
+++ b/debian/extra/handle-service-restart-in-policy
@@ -7,7 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 ###############################################################
 
-POLICY_FILE="/usr/sbin/policy-rc.d"
+POLICY_FILE="${POLICY_FILE:-/usr/sbin/policy-rc.d}"
 
 check_root() {
     if [ "$EUID" -ne 0 ]; then
@@ -57,11 +57,11 @@ add_service_to_policy() {
 
     if grep -q "exit 0" "$POLICY_FILE"; then
         # Insert before exit 0
-        sed -i "\$i\\if [ \"\$1\" = \"$service_name\" ]; then\\n    exit 101\\nfi\\n" "$POLICY_FILE"
+        sed -i "\$i\\if [ \"\$1\" = \"$service_name\" ]; then\\n    echo \"Skipping service $service_name restart...\" 1>&2\\n    exit 101\\nfi\\n" "$POLICY_FILE"
     else
-        # Append to file
+        # Append to end of file
         echo "if [ \"\$1\" = \"$service_name\" ]; then" >> "$POLICY_FILE"
-        echo "echo \"Skipping $service_name restart...\" 1>&2" >> "$POLICY_FILE"
+        echo "    echo \"Skipping service $service_name restart...\" 1>&2" >> "$POLICY_FILE"
         echo "    exit 101" >> "$POLICY_FILE"
         echo "fi" >> "$POLICY_FILE"
         echo "" >> "$POLICY_FILE"
@@ -95,12 +95,9 @@ set_policy_permissions() {
     chown root:root "$POLICY_FILE"
 }
 
-handle_service_policy() {
+handle_operation() {
     local command="$1"
     local service_name="$2"
-
-    check_root || return 1
-    validate_args "$command" "$service_name" || return 1
 
     if [ "$command" = "add" ]; then
         init_policy_file
@@ -108,10 +105,21 @@ handle_service_policy() {
     else
         [ ! -f "$POLICY_FILE" ] && {
             echo "Policy file does not exist, nothing to remove"
-            return 0
+            exit 0
         }
         remove_service_from_policy "$service_name"
     fi
+
+}
+
+handle_service_policy() {
+    local command="$1"
+    local service_name="$2"
+
+    check_root || return 1
+    validate_args "$command" "$service_name" || return 1
+
+    handle_operation "$command" "$service_name"
 
     set_policy_permissions
 }

--- a/debian/pt-os-web-portal.install
+++ b/debian/pt-os-web-portal.install
@@ -1,2 +1,3 @@
 pt_os_web_portal/rover_controller/pt-os-web-portal-rover-controller       /usr/bin/
 pt_os_web_portal/pt-os-web-portal                                         /usr/bin/
+debian/extra/handle-service-restart-in-policy                             /usr/lib/pt-os-web-portal

--- a/debian/pt-os-web-portal.postinst
+++ b/debian/pt-os-web-portal.postinst
@@ -11,6 +11,12 @@ get_reverse_dependencies() {
 	apt-cache rdepends --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed $1 2>/dev/null | uniq | grep -v -E "Reverse Depends:|$1" | xargs
 }
 
+is_installed() {
+	package_name="$1"
+	[ -n "$(apt-cache policy "$package_name" 2>/dev/null | grep -E '^[[:space:]]*Installed:')" ]
+	return $?
+}
+
 case "$1" in
   configure)
 	# if network-manager-gnome was manually installed, skip
@@ -22,6 +28,20 @@ case "$1" in
 				echo "Hidden=true" >> /etc/xdg/autostart/nm-applet.desktop
 			fi
 		fi
+	fi
+
+	# don't restart networking services during upgrade to avoid client disconnects
+	if is_installed hostapd; then
+		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add hostapd
+		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add hostapd.service
+	fi
+	if is_installed isc-dhcp-server; then
+		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add isc-dhcp-server
+		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add isc-dhcp-server.service
+	fi
+	if is_installed network-manager; then
+		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add NetworkManager
+		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add NetworkManager.service
 	fi
 
   ;;

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -7,7 +7,7 @@ gevent-websocket python3-gevent-websocket; PEP386
 nmcli python3-nmcli; PEP386
 # Package will always update in-step with SDK
 # So avoid version-locking
-pitop python3-pitop
+pitop python3-pitop; PEP386
 requests python3-requests; PEP386
 websockets python3-websockets; PEP386
 pt-web-vnc pt-web-vnc; PEP386

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     # Package will always update in-step with SDK
     # So avoid version-locking
-    pitop
+    pitop>=0.34.0
     # Main package needed since 'labs' is in it.
     # Actual subpackage dependencies are:
     # pitop.battery

--- a/tests/test_handle_service_restart_functions.py
+++ b/tests/test_handle_service_restart_functions.py
@@ -1,0 +1,225 @@
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+SCRIPT_PATH = "debian/extra/handle-service-restart-in-policy"
+POLICY_FILE = "/usr/sbin/policy-rc.d"
+POLICY_FILE_TEMP = tempfile.mktemp()
+
+
+def run_bash_function(func_name, *args):
+    """Run a specific bash function from the script"""
+    # Creates a temporary version of the script without the final execution line
+    # to be able to source the script and use the functions in the tests
+    args_str = " ".join(f"'{arg}'" for arg in args)
+    temp_file = tempfile.mktemp()
+    cmd = f"""
+    # Read all lines except the last one
+    head -n -1 {SCRIPT_PATH} > {temp_file}
+    source {temp_file}
+    rm -r {temp_file}
+    {func_name} {args_str}
+    """
+    return subprocess.run(
+        ["bash", "-c", cmd],
+        capture_output=True,
+        text=True,
+        env={"POLICY_FILE": POLICY_FILE_TEMP, "EUID": "0"},
+    )
+
+
+@pytest.fixture
+def mock_policy_file(request):
+    """Mock policy file for testing. If a service_name is provided, the corresponding section is added to the policy file."""
+    service_name = getattr(request, "param", None)
+    service_section = ""
+    if service_name is not None:
+        service_section = f"""if [ "$1" = "{service_name}" ]; then
+        exit 101
+    fi
+"""
+    content = f"""#!/bin/sh
+{service_section}
+exit 0
+"""
+    # Write the content to the policy file
+    with open(POLICY_FILE_TEMP, "w") as f:
+        f.write(content)
+    yield
+    # Cleanup
+    os.remove(POLICY_FILE_TEMP)
+
+
+def get_policy_file_content():
+    if not os.path.exists(POLICY_FILE_TEMP):
+        return None
+    with open(POLICY_FILE_TEMP, "r") as f:
+        return f.read()
+
+
+# validate_args function
+def test_validate_args_add_command():
+    result = run_bash_function("validate_args", "add", "myservice")
+    assert result.returncode == 0
+
+
+def test_validate_args_remove_command():
+    result = run_bash_function("validate_args", "remove", "myservice")
+    assert result.returncode == 0
+
+
+def test_validate_args_invalid_command():
+    result = run_bash_function("validate_args", "invalid", "myservice")
+    assert result.returncode == 1
+    assert "Invalid command. Use 'add' or 'remove'" in result.stdout
+
+
+def test_validate_args_missing_service_name():
+    result = run_bash_function("validate_args", "add", "")
+    assert result.returncode == 1
+    assert "Please provide both command and service name" in result.stdout
+
+
+# is_service_in_policy function
+@pytest.mark.parametrize(
+    "mock_policy_file", ["the-service"], indirect=["mock_policy_file"]
+)
+def test_is_service_in_policy_with_service_that_exists(mock_policy_file):
+    result = run_bash_function("is_service_in_policy", "the-service")
+    assert result.returncode == 0
+
+
+def test_is_service_in_policy_with_service__that_does_not_exists(mock_policy_file):
+    result = run_bash_function("is_service_in_policy", "another-service")
+    assert result.returncode == 1
+
+
+# add_service_to_policy function
+def test_add_service_to_policy_new_service(mock_policy_file):
+    result = run_bash_function("add_service_to_policy", "the-service")
+    assert result.returncode == 0
+    assert f"Policy added for the-service into {POLICY_FILE_TEMP}" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "mock_policy_file", ["the-service"], indirect=["mock_policy_file"]
+)
+def test_add_service_to_policy_existing_service(mock_policy_file):
+    result = run_bash_function("add_service_to_policy", "the-service")
+    assert result.returncode == 0
+    assert "Service the-service already in policy - skipping" in result.stdout
+
+
+# remove_service_from_policy function
+@pytest.mark.parametrize(
+    "mock_policy_file", ["the-service"], indirect=["mock_policy_file"]
+)
+def test_remove_existing_service(mock_policy_file):
+    result = run_bash_function("remove_service_from_policy", "the-service")
+    assert result.returncode == 0
+    assert "Policy removed for the-service" in result.stdout
+
+
+def test_remove_nonexistent_service(mock_policy_file):
+    result = run_bash_function("remove_service_from_policy", "non-existent")
+    assert result.returncode == 0
+    assert "non-existent not found in policy" in result.stdout
+
+
+def test_handle_operation_add_remove():
+    """Integration test for adding and then removing a service"""
+    # Add a service
+    result = run_bash_function("handle_operation", "add", "test-service")
+    assert result.returncode == 0
+    assert "Policy added for test-service" in result.stdout
+    assert (
+        get_policy_file_content()
+        == """#!/bin/sh
+
+if [ "$1" = "test-service" ]; then
+    echo "Skipping service test-service restart..." 1>&2
+    exit 101
+fi
+
+exit 0
+"""
+    )
+
+    # Add the same service again
+    result = run_bash_function("handle_operation", "add", "test-service")
+    assert result.returncode == 0
+    assert "Service test-service already in policy - skipping" in result.stdout
+    assert (
+        get_policy_file_content()
+        == """#!/bin/sh
+
+if [ "$1" = "test-service" ]; then
+    echo "Skipping service test-service restart..." 1>&2
+    exit 101
+fi
+
+exit 0
+"""
+    )
+    # Add another service
+    result = run_bash_function("handle_operation", "add", "another-service")
+    assert result.returncode == 0
+    assert "Policy added for another-service" in result.stdout
+    assert (
+        get_policy_file_content()
+        == """#!/bin/sh
+
+if [ "$1" = "test-service" ]; then
+    echo "Skipping service test-service restart..." 1>&2
+    exit 101
+fi
+
+if [ "$1" = "another-service" ]; then
+    echo "Skipping service another-service restart..." 1>&2
+    exit 101
+fi
+
+exit 0
+"""
+    )
+
+    # Remove the services
+    result = run_bash_function("handle_operation", "remove", "another-service")
+    assert result.returncode == 0
+    assert "Policy removed for another-service" in result.stdout
+    assert (
+        get_policy_file_content()
+        == """#!/bin/sh
+
+if [ "$1" = "test-service" ]; then
+    echo "Skipping service test-service restart..." 1>&2
+    exit 101
+fi
+
+exit 0
+"""
+    )
+    result = run_bash_function("handle_operation", "remove", "test-service")
+    assert result.returncode == 0
+    assert "Policy removed for test-service" in result.stdout
+    assert (
+        get_policy_file_content()
+        == """#!/bin/sh
+
+exit 0
+"""
+    )
+
+    # Run remove again
+    result = run_bash_function("handle_operation", "remove", "test-service")
+    assert result.returncode == 0
+    assert "Service test-service not found in policy - skipping ..." in result.stdout
+    assert (
+        get_policy_file_content()
+        == """#!/bin/sh
+
+exit 0
+"""
+    )


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready| [Ticket](https://pi-top.atlassian.net/browse/OS-1445) |


#### Main changes
- Disable restart of networking services to avoid client from getting disconnected. Services are restarted by `invoke-rc.d` in the postinst script of the package who owns the service.
- Add an exit clause to `policy-rc.d` to exit before the restart is performed.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
