### PR TITLE
Show restart page for devices with onboarding

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,6 +38,7 @@ Depends:
 # Other pi-top dependencies
  pi-topd (>= 5.7.0-1),
  pt-firmware-updater (>= 4.2.0-1),
+ pt-unattended-upgrades,
 Description: pi-topOS Web Portal
  pi-topOS's web portal. Provides means to interact and configure the device
  over a web application.

--- a/frontend/src/components/onboarding_app/App.tsx
+++ b/frontend/src/components/onboarding_app/App.tsx
@@ -23,6 +23,8 @@ import closeFirstBootAppWindow from "../../services/closeFirstBootAppWindow";
 import { runningOnWebRenderer } from "../../helpers/utils";
 import CloseButton from "../closeButton/CloseButton";
 import stopFirstBootAppAutostart from "../../services/stopFirstBootAppAutostart";
+import isOnOpenboxSession from "../../services/isOnOpenboxSession";
+import RestartPageContainer from "../../pages/restartPage/RestartPageContainer";
 
 export default () => {
   const [buildInfo, setBuildInfo] = useState<BuildInfo>();
@@ -149,10 +151,10 @@ export default () => {
               goToPreviousPage={() => {
                 history.push(skipUpgradePage ? PageRoute.Wifi : PageRoute.Upgrade);
               }}
-              goToNextPage={() => {
+              goToNextPage={async () => {
                 addCompleted(Page.Registration);
-
-                history.push(PageRoute.Finish);
+                const shouldGoToRestartPage = await isOnOpenboxSession();
+                history.push(shouldGoToRestartPage ? PageRoute.RestartPage : PageRoute.Finish);
               }}
             />
           )}
@@ -167,6 +169,15 @@ export default () => {
                 history.push(PageRoute.LandingSplash);
                 window.location.reload();
               }}
+            />
+          )}
+        />
+
+        <Route
+          path={PageRoute.RestartPage}
+          render={({ history }) => (
+            <RestartPageContainer
+              goToPreviousPage={() => history.push(PageRoute.Registration)}
             />
           )}
         />

--- a/frontend/src/msw/handlers.ts
+++ b/frontend/src/msw/handlers.ts
@@ -113,4 +113,10 @@ export default [
       })
     );
   }),
+  rest.post("/reboot", (_, res, ctx) => {
+    return res(ctx.body("OK"));
+  }),
+  rest.get("/is-on-openbox-session", (_, res, ctx) => {
+    return res(ctx.json({ isOnOpenboxSession: false }));
+  }),
 ];

--- a/frontend/src/pages/finalOnboardingPage/FinalOnboardingPage.tsx
+++ b/frontend/src/pages/finalOnboardingPage/FinalOnboardingPage.tsx
@@ -18,7 +18,7 @@ export default ({ onBackClick, onNextClick }: Props) => {
     <Layout
       banner={{
         src: rebootScreen,
-        alt: "reboot-screen",
+        alt: "final-screen",
       }}
       prompt={
         <>

--- a/frontend/src/pages/finalOnboardingPage/__tests__/FinalOnboardingPage.test.tsx
+++ b/frontend/src/pages/finalOnboardingPage/__tests__/FinalOnboardingPage.test.tsx
@@ -34,7 +34,7 @@ describe("FinalOnboardingPage", () => {
   });
 
   it("renders correct image", () => {
-    expect(getByAltText("reboot-screen")).toMatchSnapshot();
+    expect(getByAltText("final-screen")).toMatchSnapshot();
   });
 
   it("renders prompt correctly", () => {

--- a/frontend/src/pages/finalOnboardingPage/__tests__/__snapshots__/FinalOnboardingPage.test.tsx.snap
+++ b/frontend/src/pages/finalOnboardingPage/__tests__/__snapshots__/FinalOnboardingPage.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FinalOnboardingPage renders correct image 1`] = `
 <img
-  alt="reboot-screen"
+  alt="final-screen"
   class="image"
   draggable="false"
   src="reboot-screen.png"

--- a/frontend/src/pages/restartPage/RestartPage.module.css
+++ b/frontend/src/pages/restartPage/RestartPage.module.css
@@ -1,0 +1,26 @@
+.banner {
+}
+
+.progress {
+  margin-top: 30px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.progressBar {
+  color: var(--green);
+}
+
+.message {
+  composes: text from '../../globalStyles/Typography.module.css';
+  padding: 20px;
+  font-size: 16px;
+  color: var(--green);
+}
+
+.error {
+  composes: fontError from '../../globalStyles/Typography.module.css';
+  font-size: 18px;
+}

--- a/frontend/src/pages/restartPage/RestartPage.tsx
+++ b/frontend/src/pages/restartPage/RestartPage.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useEffect } from "react";
+import { Line as ProgressBar } from "rc-progress";
+
+import Layout from "../../components/layout/Layout";
+import Spinner from "../../components/atoms/spinner/Spinner";
+
+import rebootScreen from "../../assets/images/reboot-screen.png";
+import styles from "./RestartPage.module.css";
+
+import { runningOnWebRenderer } from "../../helpers/utils";
+import ConnectivityWarningDialog from "./connectivityWarningDialog/ConnectivityWarningDialog";
+
+export enum ErrorMessage {
+  GlobalError = "Something went wrong while setting me up! Please click 'Restart' and contact support@pi-top.com if you experience any problems",
+  RebootError = "I can't get to sleep! Please hold my power button down - that always makes me sleepy",
+  TimeoutError = "It seems as though this is taking longer than expected. Ensure you are on the correct network and try refreshing this webpage in your browser. Otherwise, try restarting your pi-top device."
+}
+
+export enum ServerStatusMessages {
+  Waiting = "Rebooting. Please wait until this pi-top device is back online",
+  Online = "The device is back online!"
+}
+
+export enum ExplanationMessages {
+  OnWebRenderer = "Press 'restart' and I'll set some stuff up before rebooting. This might take up to a couple of minutes.",
+  OnBrowser = "Press 'restart' to apply some final changes to your pi-top device and restart it.\n\nThis page will automatically update when the device is ready - this might take up to a couple of minutes, so don't go anywhere",
+  CheckingConnectivity = "Please wait - we're performing some checks before continuing...",
+}
+
+export type Props = {
+  isWaitingForServer: boolean
+  serverRebooted: boolean
+  globalError: boolean;
+  isSettingUpDevice: boolean;
+  rebootError: boolean;
+  progressPercentage: number;
+  progressMessage: string;
+  checkingOnSameNetwork: boolean;
+  shouldMoveAwayFromAp: boolean;
+  piTopIpAddress: string;
+  shouldDisplayConnectivityDialog: boolean,
+  setupDevice: () => void;
+  onBackClick?: () => void;
+};
+
+export default ({
+  isWaitingForServer,
+  serverRebooted,
+  globalError,
+  isSettingUpDevice,
+  rebootError,
+  progressPercentage,
+  progressMessage,
+  shouldMoveAwayFromAp,
+  shouldDisplayConnectivityDialog,
+  checkingOnSameNetwork,
+  piTopIpAddress,
+  setupDevice,
+  onBackClick,
+}: Props) => {
+  const [connectivityDialogActive, setConnectivityDialogActive] = useState(false);
+
+  useEffect(() => {
+    !checkingOnSameNetwork && shouldDisplayConnectivityDialog && setConnectivityDialogActive(true);
+  }, [checkingOnSameNetwork, shouldDisplayConnectivityDialog])
+
+  let errorMessage = "";
+  if (globalError) {
+    errorMessage = ErrorMessage.GlobalError;
+  }
+
+  if (rebootError) {
+    errorMessage = isWaitingForServer ? ErrorMessage.TimeoutError : ErrorMessage.RebootError;
+  }
+
+  const getExplanationMessage = () => {
+    if (checkingOnSameNetwork) {
+      return ExplanationMessages.CheckingConnectivity;
+    }
+    if (runningOnWebRenderer()) {
+      return ExplanationMessages.OnWebRenderer
+    }
+    return ExplanationMessages.OnBrowser;
+  }
+
+  return (
+    <Layout
+      banner={{
+        src: rebootScreen,
+        alt: "reboot-screen",
+      }}
+      prompt={
+        <>
+          Right, I need a quick <span className="green">nap</span>
+        </>
+      }
+      explanation={getExplanationMessage()}
+      nextButton={{
+        onClick: setupDevice,
+        label: "Restart",
+        disabled: isSettingUpDevice || rebootError || isWaitingForServer || checkingOnSameNetwork || connectivityDialogActive,
+        hidden: isWaitingForServer || serverRebooted
+      }}
+      backButton={
+        (globalError || !onBackClick)
+          ? undefined
+          : {
+              onClick: onBackClick,
+              disabled: isSettingUpDevice || isWaitingForServer || connectivityDialogActive,
+              hidden: isWaitingForServer || serverRebooted || checkingOnSameNetwork
+            }
+      }
+      className={styles.root}
+    >
+      {!checkingOnSameNetwork && shouldDisplayConnectivityDialog && <ConnectivityWarningDialog
+        shouldMoveAwayFromAp={shouldMoveAwayFromAp}
+        active={connectivityDialogActive}
+        onSkip={() => {
+          setConnectivityDialogActive(!connectivityDialogActive);
+        }}
+        onContinue={() => {
+          setConnectivityDialogActive(!connectivityDialogActive);
+        }}
+        piTopIpAddress={piTopIpAddress}
+      />}
+
+      {isSettingUpDevice && (
+        <div className={styles.progress}>
+          <ProgressBar
+            percent={progressPercentage}
+            strokeWidth={2}
+            strokeColor="#71c0b4"
+          />
+          <span className={styles.message}>{progressMessage}</span>
+        </div>
+      )}
+
+      {isWaitingForServer ? (
+        <>
+          <span className={styles.message}>{ServerStatusMessages.Waiting}</span>
+          <Spinner size={40} />{" "}
+        </>
+      ):(
+        serverRebooted && <span className={styles.message}>{ServerStatusMessages.Online}</span>
+      )}
+
+      {errorMessage && <span className={styles.error}>{errorMessage}</span>}
+    </Layout>
+  );
+};

--- a/frontend/src/pages/restartPage/RestartPageContainer.tsx
+++ b/frontend/src/pages/restartPage/RestartPageContainer.tsx
@@ -1,0 +1,219 @@
+import React, { useState, useEffect } from "react";
+import { useHistory } from 'react-router-dom';
+
+import RestartPage from "./RestartPage";
+
+import configureLanding from "../../services/configureLanding";
+import deprioritiseOpenboxSession from "../../services/deprioritiseOpenboxSession";
+import enableFirmwareUpdaterService from "../../services/enableFirmwareUpdaterService";
+import enableFurtherLinkService from "../../services/enableFurtherLinkService";
+import stopOnboardingAutostart from "../../services/stopOnboardingAutostart";
+import reboot from "../../services/reboot";
+import restoreFiles from "../../services/restoreFiles";
+import serverStatus from "../../services/serverStatus"
+import updateEeprom from "../../services/updateEeprom"
+import enablePtMiniscreen from "../../services/enablePtMiniscreen";
+import disableApMode from "../../services/disableApMode";
+import verifyDeviceNetwork from "../../services/verifyDeviceNetwork";
+
+import { runningOnWebRenderer } from "../../helpers/utils";
+
+const maxProgress = 11; // this is the number of services for setting up
+
+const calculatePercentageProgress = (progress: number, maxProgress: number) => {
+  if (!Number.isFinite(progress / maxProgress)) {
+    return 100;
+  }
+
+  return Math.floor((progress / maxProgress) * 100);
+};
+
+export type Props = {
+  globalError?: boolean;
+  goToPreviousPage?: () => void;
+};
+
+export default ({
+  globalError = false,
+  goToPreviousPage,
+}: Props) => {
+  const history = useHistory();
+  const [isSettingUpDevice, setIsSettingUpDevice] = useState(false);
+  const [rebootError, setRebootError] = useState(false);
+  const [progressMessage, setProgressMessage] = useState("Alright let's get started!");
+  const [progress, setProgress] = useState(0);
+  const [isWaitingForServer, setIsWaitingForServer] = useState(false);
+  const [serverRebooted, setServerRebooted] = useState(false);
+  const [checkingOnSameNetwork, setCheckingOnSameNetwork] = useState(true);
+  const [shouldMoveAwayFromAp, setShouldMoveAwayFromAp] = useState(false);
+  const [shouldDisplayConnectivityDialog, setShouldDisplayConnectivityDialog] = useState(false);
+  const [piTopIpAddress, setPiTopIpAddress] = useState<string>("pi-top.local");
+
+  useEffect(() => {
+    verifyDeviceNetwork()
+      .then((data) => {
+        setShouldMoveAwayFromAp(data.shouldSwitchNetwork);
+        data.piTopIp && setPiTopIpAddress(data.piTopIp);
+        setShouldDisplayConnectivityDialog(data.shouldDisplayDialog);
+      })
+      .catch(() => null)
+      .finally(() => setCheckingOnSameNetwork(false));
+  }, []);
+
+  // stop users leaving page when setting up or waiting for reboot to finish.
+  useEffect(() => {
+    if (!(isSettingUpDevice || isWaitingForServer)) {
+      return;
+    }
+
+    function beforeUnloadListener(event: BeforeUnloadEvent) {
+      // prevent leaving page without confirmation
+      event.preventDefault();
+      event.returnValue = true // chrome requires return value to be set
+    }
+
+    window.addEventListener("beforeunload", beforeUnloadListener);
+    return () =>
+      window.removeEventListener("beforeunload", beforeUnloadListener);
+  }, [isSettingUpDevice, isWaitingForServer]);
+
+  function safelyRunService(service: () => Promise<void>, message: string) {
+    return service()
+      .then(() => setProgressMessage(message))
+      .catch(() =>
+        setProgressMessage(
+          "I couldn't do that, please contact support if I have any problems..."
+        )
+      )
+      .finally(() => {
+        setProgress(currentProgess =>
+          Math.min(currentProgess + 1, maxProgress)
+        );
+      });
+  }
+
+  const rebootTimeoutMs = 120000;
+  const timeoutServerStatusRequestMs = 500;
+  const serverStatusRequestIntervalMs = 1500;
+  let elapsedWaitingTimeMs = 0;
+
+  function waitUntilServerIsOnline() {
+    const interval = setInterval(async () => {
+      try {
+        elapsedWaitingTimeMs += timeoutServerStatusRequestMs + serverStatusRequestIntervalMs;
+        elapsedWaitingTimeMs >= rebootTimeoutMs && setRebootError(true);
+        await serverStatus({ timeout: timeoutServerStatusRequestMs });
+        setServerRebooted(true);
+        setIsWaitingForServer(false);
+        clearInterval(interval);
+        history.push("/");
+        window.location.reload()
+      } catch (_) {}
+    }, serverStatusRequestIntervalMs);
+  }
+
+  function rebootPiTop() {
+    reboot()
+      .then(() => {
+        if (!runningOnWebRenderer()) {
+          setIsSettingUpDevice(false);
+          setIsWaitingForServer(true);
+          setServerRebooted(false);
+          window.setTimeout(waitUntilServerIsOnline, 3000);
+        }
+      })
+      .catch(() => {
+        setRebootError(true);
+        setIsSettingUpDevice(false);
+      })
+  }
+
+
+  return (
+    <RestartPage
+      isWaitingForServer={isWaitingForServer}
+      serverRebooted={serverRebooted}
+      globalError={globalError}
+      isSettingUpDevice={isSettingUpDevice}
+      rebootError={rebootError}
+      progressPercentage={calculatePercentageProgress(progress, maxProgress)}
+      progressMessage={progressMessage}
+      onBackClick={goToPreviousPage}
+      checkingOnSameNetwork={checkingOnSameNetwork}
+      shouldMoveAwayFromAp={shouldMoveAwayFromAp}
+      shouldDisplayConnectivityDialog={shouldDisplayConnectivityDialog}
+      piTopIpAddress={piTopIpAddress}
+      setupDevice={() => {
+        setIsSettingUpDevice(true);
+
+        safelyRunService(
+          enableFirmwareUpdaterService,
+          "Reminded myself to keep an eye out for cool new stuff for my friends..."
+        )
+          .finally(() =>
+            safelyRunService(
+              enableFurtherLinkService,
+              "Reminded myself to stay connected, so I can help you go Further..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              deprioritiseOpenboxSession,
+              "Put away all my open boxes..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              restoreFiles,
+              "Reminded myself to show you around..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              configureLanding,
+              "Reminded myself to show you around..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              stopOnboardingAutostart,
+              "Made sure not to make you go through this again..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              updateEeprom,
+              "Made things easier for me to go to sleep when you ask..."
+            )
+          )
+          .finally(() =>
+            safelyRunService(
+              enablePtMiniscreen,
+              "Reminded myself to tell the miniscreen to do its thing in the morning..."
+            )
+          )
+          .finally(() =>
+            // shouldDisplayConnectivityDialog = client using AP network
+            // shouldMoveAwayFromAp = pi-top has networks other than AP
+            //
+            // so turn off AP if !shouldDisplayConnectivityDialog || shouldMoveAwayFromAp
+            // = client not using AP or they are but there is an alternative
+            //
+            // ...except if there is an alternative they should have already been
+            // prompted to switch to it before tiggering these actions...
+            // if they didn't follow that prompt, we need to keep AP on despite alternatives
+            //
+            // so actually only turn AP off if they are not using it currently... !shouldDisplayConnectivityDialog
+            !shouldDisplayConnectivityDialog && safelyRunService(
+              disableApMode,
+              "Disabling my access point..."
+            )
+          )
+          .catch(console.error)
+          .finally(() => {
+              rebootPiTop();
+          })
+      }}
+    />
+  );
+};

--- a/frontend/src/pages/restartPage/__tests__/RestartPage.test.tsx
+++ b/frontend/src/pages/restartPage/__tests__/RestartPage.test.tsx
@@ -1,0 +1,269 @@
+import React from "react";
+import {
+  render,
+  fireEvent,
+  BoundFunction,
+  GetByBoundAttribute,
+  QueryByText,
+  GetByText,
+  RenderResult,
+  QueryByBoundAttribute,
+  wait,
+} from "@testing-library/react";
+
+import RestartPage, { Props, ErrorMessage, ExplanationMessages } from "../RestartPage";
+
+describe("RestartPage", () => {
+  let defaultProps: Props;
+  let restartPage: HTMLElement;
+  let getByAltText: BoundFunction<GetByBoundAttribute>;
+  let queryByText: BoundFunction<QueryByText>;
+  let getByText: BoundFunction<GetByText>;
+  let queryByTestId: BoundFunction<QueryByBoundAttribute>;
+  let rerender: RenderResult["rerender"];
+
+  beforeEach(() => {
+    defaultProps = {
+      onBackClick: jest.fn(),
+      setupDevice: jest.fn(),
+      isSettingUpDevice: false,
+      progressPercentage: 0.5,
+      progressMessage: "I am setting up",
+      rebootError: false,
+      globalError: false,
+      isWaitingForServer: false,
+      serverRebooted: false,
+      piTopIpAddress: "pi-top.local",
+      shouldDisplayConnectivityDialog: false,
+      shouldMoveAwayFromAp: false,
+      checkingOnSameNetwork: false,
+      onConnectivityDialogSkip: jest.fn(),
+    };
+
+    ({
+      container: restartPage,
+      getByAltText,
+      queryByText,
+      queryByTestId,
+      getByText,
+      rerender,
+    } = render(<RestartPage {...defaultProps} />));
+  });
+
+  it("renders correct image", () => {
+    expect(getByAltText("reboot-screen")).toMatchSnapshot();
+  });
+
+  it("renders prompt correctly", () => {
+    const prompt = restartPage.querySelector(".prompt");
+    expect(prompt).toMatchSnapshot();
+  });
+
+  it("renders explanation", () => {
+    ExplanationMessages.OnBrowser.split('\n').map(function(item, _) {
+      item && expect(getByText(item)).toBeInTheDocument();
+    });
+  });
+
+  it("doesn't render error message", () => {
+    expect(queryByTestId("error-message")).not.toBeInTheDocument();
+  });
+
+  it("doesn't render connectivity dialog", () => {
+    expect(queryByTestId("connectivity-dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders restart button", () => {
+    expect(queryByText("Restart")).toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    expect(queryByText("Back")).toBeInTheDocument();
+  });
+
+  it("doesn't render skip button", () => {
+    expect(queryByText("Skip")).not.toBeInTheDocument();
+  });
+
+  it("Back button isn't disabled", () => {
+    expect(getByText("Back")).toHaveProperty("disabled", false);
+  });
+
+  it("Restart button isn't disabled", () => {
+    expect(getByText("Restart").parentElement).toHaveProperty("disabled", false);
+  });
+
+  it("calls onBackClick on back button click", () => {
+    fireEvent.click(getByText("Back"));
+
+    expect(defaultProps.onBackClick).toHaveBeenCalled();
+  });
+
+  it('calls setupDevice on restart button click', () => {
+    fireEvent.click(getByText('Restart'));
+
+    expect(defaultProps.setupDevice).toHaveBeenCalled();
+  })
+
+  describe("when isSettingUpDevice is true and progress info is passed", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        isSettingUpDevice: true,
+      };
+
+      rerender(<RestartPage {...defaultProps} />);
+    });
+
+    it("renders progress message", () => {
+      expect(queryByText(defaultProps.progressMessage)).toBeInTheDocument();
+    });
+
+    it("renders progress bar correctly", () => {
+      expect(restartPage.querySelector('.progress')).toMatchSnapshot();
+    });
+
+    it("disables the restart button", () => {
+      expect(getByText("Restart").parentElement).toBeDisabled();
+    });
+  });
+
+  describe("when rebootError is true", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        rebootError: true,
+      };
+
+      rerender(<RestartPage {...defaultProps} />);
+    });
+
+    it("renders correct error message", () => {
+      expect(queryByText(ErrorMessage.RebootError)).toBeInTheDocument();
+    });
+
+    it("disables restart button", () => {
+      expect(queryByText("Restart")?.parentElement).toBeDisabled();
+    });
+  });
+
+  describe("when globalError is true", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        globalError: true,
+      };
+
+      rerender(<RestartPage {...defaultProps} />);
+    });
+
+    it("renders correct error message", () => {
+      expect(queryByText(ErrorMessage.GlobalError)).toBeInTheDocument();
+    });
+
+    it("doesn't render skip button", () => {
+      expect(queryByText("Skip")).not.toBeInTheDocument();
+    });
+
+    it("doesn't render back button", () => {
+      expect(queryByText("Back")).not.toBeInTheDocument();
+    })
+
+    it("renders restart button", () => {
+      expect(queryByText("Restart")).toBeInTheDocument();
+    });
+
+    it('calls setupDevice on restart button click', () => {
+      fireEvent.click(getByText('Restart'));
+
+      expect(defaultProps.setupDevice).toHaveBeenCalled();
+    })
+  });
+
+  describe("when checkingOnSameNetwork is true", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        checkingOnSameNetwork: true,
+      };
+
+      rerender(<RestartPage {...defaultProps} />);
+    });
+
+    it("renders prompt correctly", () => {
+      const prompt = restartPage.querySelector(".prompt");
+      expect(prompt).toMatchSnapshot();
+    });
+
+    it("renders explanation", () => {
+      expect(getByText(ExplanationMessages.CheckingConnectivity)).toBeInTheDocument();
+    });
+
+    it("restart button is disabled", () => {
+      expect(queryByText("Restart")?.parentElement).toBeDisabled();
+    });
+
+    it("back button is hidden", () => {
+      expect(queryByText("Back")).toHaveProperty("hidden");
+    });
+  });
+
+  describe("when devices aren't on the same network", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        checkingOnSameNetwork: false,
+        shouldMoveAwayFromAp: true,
+        shouldDisplayConnectivityDialog: true,
+      };
+
+      rerender(<RestartPage {...defaultProps} />);
+    });
+
+    it("renders the dialog", () => {
+      expect(queryByTestId("connectivity-dialog")).toBeInTheDocument();
+    });
+
+    it("displays the dialog", () => {
+      expect(queryByTestId("connectivity-dialog")).not.toHaveClass("hidden");
+    });
+
+    it("disables restart button", () => {
+      expect(queryByText("Restart")?.parentElement).toBeDisabled();
+    });
+
+    it("disables back button", () => {
+      expect(queryByText("Back")).toBeDisabled();
+    });
+  });
+
+  describe("when the only connection method is AP", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        checkingOnSameNetwork: false,
+        shouldMoveAwayFromAp: false,
+        shouldDisplayConnectivityDialog: true,
+      };
+
+      rerender(<RestartPage {...defaultProps} />);
+    });
+
+    it("renders the dialog", () => {
+      expect(queryByTestId("connectivity-dialog")).toBeInTheDocument();
+    });
+
+    it("displays the dialog", () => {
+      expect(queryByTestId("connectivity-dialog")).not.toHaveClass("hidden");
+    });
+
+    it("disables restart button", () => {
+      expect(queryByText("Restart")?.parentElement).toBeDisabled();
+    });
+
+    it("disables back button", () => {
+      expect(queryByText("Back")).toBeDisabled();
+    });
+  });
+
+});

--- a/frontend/src/pages/restartPage/__tests__/RestartPageContainer.test.tsx
+++ b/frontend/src/pages/restartPage/__tests__/RestartPageContainer.test.tsx
@@ -1,0 +1,448 @@
+import React from "react";
+import {
+  render,
+  BoundFunction,
+  QueryByText,
+  GetByText,
+  RenderResult,
+  wait,
+  fireEvent,
+  getByLabelText,
+  waitForElement,
+  GetByBoundAttribute,
+  QueryByBoundAttribute,
+} from "@testing-library/react";
+
+import RestartPageContainer, { Props } from "../RestartPageContainer";
+import { ErrorMessage, ExplanationMessages } from "../RestartPage";
+import querySpinner from "../../../../test/helpers/querySpinner";
+
+import configureLanding from "../../../services/configureLanding";
+import deprioritiseOpenboxSession from "../../../services/deprioritiseOpenboxSession";
+import enableFurtherLinkService from "../../../services/enableFurtherLinkService";
+import enableFirmwareUpdaterService from "../../../services/enableFirmwareUpdaterService";
+import restoreFiles from "../../../services/restoreFiles";
+import stopOnboardingAutostart from "../../../services/stopOnboardingAutostart";
+import reboot from "../../../services/reboot";
+import serverStatus from "../../../services/serverStatus";
+import updateEeprom from "../../../services/updateEeprom";
+import enablePtMiniscreen from "../../../services/enablePtMiniscreen";
+import verifyDeviceNetwork from "../../../services/verifyDeviceNetwork";
+import disableApMode from "../../../services/disableApMode";
+
+
+import { act } from "react-dom/test-utils";
+
+jest.mock("../../../services/configureLanding");
+jest.mock("../../../services/deprioritiseOpenboxSession");
+jest.mock("../../../services/enableFurtherLinkService");
+jest.mock("../../../services/enableFirmwareUpdaterService");
+jest.mock("../../../services/restoreFiles");
+jest.mock("../../../services/stopOnboardingAutostart");
+jest.mock("../../../services/reboot");
+jest.mock("../../../services/serverStatus");
+jest.mock("../../../services/updateEeprom");
+jest.mock("../../../services/enablePtMiniscreen");
+jest.mock("../../../services/verifyDeviceNetwork");
+jest.mock("../../../services/disableApMode");
+
+
+const configureLandingMock = configureLanding as jest.Mock;
+const deprioritiseOpenboxSessionMock = deprioritiseOpenboxSession as jest.Mock;
+const enableFurtherLinkServiceMock = enableFurtherLinkService as jest.Mock;
+const enableFirmwareUpdaterServiceMock = enableFirmwareUpdaterService as jest.Mock;
+const restoreFilesMock = restoreFiles as jest.Mock;
+const stopOnboardingAutostartMock = stopOnboardingAutostart as jest.Mock;
+const rebootMock = reboot as jest.Mock;
+const serverStatusMock = serverStatus as jest.Mock;
+const updateEepromMock = updateEeprom as jest.Mock;
+const enablePtMiniscreenMock = enablePtMiniscreen as jest.Mock;
+const verifyDeviceNetworkMock = verifyDeviceNetwork as jest.Mock;
+const disableApModeMock = disableApMode as jest.Mock;
+
+
+const mockServices = [
+  enableFirmwareUpdaterServiceMock,
+  enableFurtherLinkServiceMock,
+  deprioritiseOpenboxSessionMock,
+  restoreFilesMock,
+  configureLandingMock,
+  stopOnboardingAutostartMock,
+  updateEepromMock,
+  enablePtMiniscreenMock,
+  disableApModeMock,
+  rebootMock,
+];
+
+
+const resolveMocks = (mocks: jest.Mock[] = mockServices) => {
+  mocks.forEach((mock) => {
+    mock.mockResolvedValue("OK");
+  });
+};
+
+const rejectMocks = (mocks: jest.Mock[] = mockServices) => {
+  mocks.forEach((mock, i) => {
+    mock.mockRejectedValue(new Error(`Test error message ${i}`));
+  });
+};
+
+let mockUserAgent = "web-renderer";
+Object.defineProperty(global.navigator, "userAgent", {
+  get() {
+    return mockUserAgent;
+  },
+});
+
+
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+const userMustConfirmBeforeLeaving = () => {
+  // dispatch beforeunload event to simulate beginning of unload process
+  const event = new Event('beforeunload')
+  const preventDefaultSpy = jest.spyOn(event, "preventDefault");
+  window.dispatchEvent(event);
+
+  // calling preventDefault causes most browsers to confirm leaving with user
+  // event.returnValue needs to be set for chrome
+  return (
+    preventDefaultSpy.mock.calls.length > 0 &&
+    event.returnValue
+  );
+};
+
+describe("RestartPageContainer", () => {
+  let defaultProps: Props;
+  let restartPageContainer: HTMLElement;
+  let queryByText: BoundFunction<QueryByText>;
+  let getByText: BoundFunction<GetByText>;
+  let queryByTestId: BoundFunction<QueryByBoundAttribute>;
+  let getByTestId: BoundFunction<GetByBoundAttribute>;
+  let rerender: RenderResult["rerender"];
+
+  beforeEach(async () => {
+    resolveMocks();
+    serverStatusMock.mockResolvedValue("OK");
+    verifyDeviceNetworkMock.mockResolvedValue({
+      shouldSwitchNetwork: false,
+      shouldDisplayDialog: false,
+      piTopIp: "192.168.64.1",
+      clientIp: "192.168.64.10",
+    });
+    mockUserAgent = "web-renderer";
+    defaultProps = {};
+
+    ({
+      container: restartPageContainer,
+      queryByText,
+      getByText,
+      rerender,
+      queryByTestId,
+      getByTestId,
+    } = render(<RestartPageContainer {...defaultProps} />));
+  });
+  afterEach(() => {
+    mockServices.forEach((mock) => {
+      mock.mockRestore();
+    });
+  });
+
+  it("does not render back button", () => {
+    expect(queryByText("Back")).not.toBeInTheDocument();
+  });
+
+  it("does not render error message", () => {
+    expect(
+      restartPageContainer.querySelector(".error")
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not ask user for confirmation before they leave the page", async () => {
+    expect(userMustConfirmBeforeLeaving()).toBeFalsy();
+  });
+
+  it("renders prompt correctly", async () => {
+    expect(restartPageContainer.querySelector(".prompt")).toMatchSnapshot();
+  });
+
+  it("calls verifyDeviceNetwork service", async () => {
+    expect(verifyDeviceNetworkMock).toHaveBeenCalled()
+  });
+
+  it("doesn't render connectivity dialog", async () => {
+    expect(queryByTestId("connectivity-dialog")).not.toBeInTheDocument();
+  });
+
+  describe("when goToPreviousPage is passed", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        goToPreviousPage: jest.fn(),
+      };
+
+      rerender(<RestartPageContainer {...defaultProps} />);
+    });
+
+    it("renders back button", () => {
+      expect(queryByText("Back")).toBeInTheDocument();
+    });
+
+    it("calls goToPreviousPage on back button click", () => {
+      fireEvent.click(getByText("Back"));
+
+      expect(defaultProps.goToPreviousPage).toHaveBeenCalled();
+    });
+
+    it("disables back button on restart click", async () => {
+      const restartButton = getByText("Restart").parentElement
+      if(restartButton) fireEvent.click(restartButton);
+
+      expect(queryByText("Back")).toBeDisabled();
+
+      await wait();
+    });
+  });
+
+  describe("on restart click", () => {
+    it("renders progress", async () => {
+      const restartButton = getByText("Restart").parentElement
+      if(restartButton) fireEvent.click(restartButton);
+
+      expect(
+        restartPageContainer.querySelector(".progress")
+      ).toBeInTheDocument();
+
+      await wait();
+    });
+
+    it("disables restart button", async () => {
+      const restartButton = getByText("Restart").parentElement
+      if(restartButton) fireEvent.click(restartButton);
+
+      expect(queryByText("Restart")?.parentElement).toBeDisabled();
+
+      await wait();
+    });
+
+    it("asks user for confirmation before they leave the page", async () => {
+      const restartButton = getByText("Restart").parentElement
+      if(restartButton) fireEvent.click(restartButton);
+      await wait();
+
+      expect(userMustConfirmBeforeLeaving()).toBeTruthy();
+
+      await wait();
+    });
+
+    it("calls correct services", async () => {
+      const restartButton = getByText("Restart").parentElement
+      if(restartButton) fireEvent.click(restartButton);
+
+      await wait();
+
+      mockServices.forEach((mock) => {
+        expect(mock).toHaveBeenCalled();
+      });
+    });
+
+    describe('when configure landing fails', () => {
+      beforeEach(() => {
+        configureLandingMock.mockRejectedValue(new Error());
+      });
+
+      it('calls remaining services', async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        mockServices.forEach((mock) => {
+          expect(mock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when deprioritise openbox session fails', () => {
+      beforeEach(() => {
+        deprioritiseOpenboxSessionMock.mockRejectedValue(new Error());
+      });
+
+      it('calls remaining services', async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        mockServices.forEach((mock) => {
+          expect(mock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when stop onboarding autostart fails', () => {
+      beforeEach(() => {
+        stopOnboardingAutostartMock.mockRejectedValue(new Error());
+      });
+
+      it('calls remaining services', async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        mockServices.forEach((mock) => {
+          expect(mock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when update EEPROM fails', () => {
+      beforeEach(() => {
+        updateEepromMock.mockRejectedValue(new Error());
+      });
+
+      it('calls remaining services', async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        mockServices.forEach((mock) => {
+          expect(mock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when disabling access point fails', () => {
+      beforeEach(() => {
+        disableApModeMock.mockRejectedValue(new Error());
+      });
+
+      it('calls remaining services', async () => {
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+
+        mockServices.forEach((mock) => {
+          expect(mock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when reboot fails', () => {
+      beforeEach(async () => {
+        rebootMock.mockRejectedValue(new Error());
+
+        fireEvent.click(getByText("Restart"));
+
+        await wait();
+      });
+
+      it('disables restart button', async () => {
+        expect(queryByText('Restart')?.parentElement).toBeDisabled();
+      });
+
+      it('renders reboot error message', () => {
+        expect(queryByText(ErrorMessage.RebootError)).toBeInTheDocument();
+      });
+
+      it('stops rendering progress', () => {
+        expect(restartPageContainer.querySelector('.progress')).not.toBeInTheDocument();
+      })
+    });
+
+    describe('after reboot call when running through an external browser', () => {
+      beforeEach(async () => {
+        jest.useFakeTimers();
+        mockUserAgent = "not-web-renderer";
+        serverStatusMock.mockResolvedValue("OK");
+        fireEvent.click(getByText("Restart"));
+        await wait();
+      });
+      afterEach(() => jest.useRealTimers());
+
+      it('displays a wait message', async () => {
+        ExplanationMessages.OnBrowser.split('\n').map(function(item, _) {
+          item && expect(getByText(item)).toBeInTheDocument();
+        });
+
+        await act(async () => {
+          jest.runOnlyPendingTimers();
+          await Promise.resolve();
+        });
+      });
+
+      it('starts querying device to learn if its back online', async () => {
+        await act(async () => {
+          jest.runOnlyPendingTimers();
+          await Promise.resolve();
+        });
+        expect(serverStatusMock).toHaveBeenCalled();
+      });
+
+      it('renders a spinner', async () => {
+        await act(async () => {
+          jest.runOnlyPendingTimers();
+          await Promise.resolve();
+        });
+        expect(querySpinner(restartPageContainer)).toBeInTheDocument();
+      });
+
+      it("asks user for confirmation before they leave the page", async () => {
+
+        const restartButton = getByText("Restart").parentElement
+        if(restartButton) fireEvent.click(restartButton);
+
+        await wait();
+
+        expect(userMustConfirmBeforeLeaving()).toBeTruthy();
+
+        await wait();
+      });
+
+      describe('when the device is back online', () => {
+        it('updates the displayed message', async () => {
+          await act(async () => {
+            jest.runOnlyPendingTimers();
+            jest.runOnlyPendingTimers();
+            await Promise.resolve();
+          });
+          expect(getByText("The device is back online!")).toBeInTheDocument()
+        });
+
+        it('doesn\'t render a spinner', async () => {
+          await act(async () => {
+            jest.runOnlyPendingTimers();
+            jest.runOnlyPendingTimers();
+            await Promise.resolve();
+          });
+          expect(querySpinner(restartPageContainer)).not.toBeInTheDocument();
+        });
+
+        it("does not ask user for confirmation before they leave the page", async () => {
+          await act(async () => {
+            jest.runOnlyPendingTimers();
+            jest.runOnlyPendingTimers();
+            await Promise.resolve();
+          });
+          expect(userMustConfirmBeforeLeaving()).toBeFalsy();
+        });
+      });
+    });
+  });
+
+  describe("when globalError is true", () => {
+    beforeEach(() => {
+      defaultProps = {
+        ...defaultProps,
+        globalError: true,
+      };
+
+      rerender(<RestartPageContainer {...defaultProps} />);
+    });
+
+    it("renders correct error message", () => {
+      expect(getByText(ErrorMessage.GlobalError)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/restartPage/__tests__/__snapshots__/RestartPage.test.tsx.snap
+++ b/frontend/src/pages/restartPage/__tests__/__snapshots__/RestartPage.test.tsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestartPage renders correct image 1`] = `
+<img
+  alt="reboot-screen"
+  class="image"
+  draggable="false"
+  src="reboot-screen.png"
+  style="max-height: 100%; max-width: 100%;"
+/>
+`;
+
+exports[`RestartPage renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  Right, I need a quick 
+  <span
+    class="green"
+  >
+    nap
+  </span>
+</h1>
+`;
+
+exports[`RestartPage when checkingOnSameNetwork is true renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  Right, I need a quick 
+  <span
+    class="green"
+  >
+    nap
+  </span>
+</h1>
+`;
+
+exports[`RestartPage when isSettingUpDevice is true and progress info is passed renders progress bar correctly 1`] = `
+<div
+  class="progress"
+>
+  <svg
+    class="rc-progress-line "
+    preserveAspectRatio="none"
+    viewBox="0 0 100 2"
+  >
+    <path
+      class="rc-progress-line-trail"
+      d="M 1,1
+           L 99,1"
+      fill-opacity="0"
+      stroke="#D9D9D9"
+      stroke-linecap="round"
+      stroke-width="1"
+    />
+    <path
+      class="rc-progress-line-path"
+      d="M 1,1
+           L 99,1"
+      fill-opacity="0"
+      stroke="#71c0b4"
+      stroke-linecap="round"
+      stroke-width="2"
+      style="stroke-dasharray: 0.5px, 100px; stroke-dashoffset: -0px; transition: stroke-dashoffset 0.3s ease 0s, stroke-dasharray .3s ease 0s, stroke 0.3s linear;"
+    />
+  </svg>
+  <span
+    class="message"
+  >
+    I am setting up
+  </span>
+</div>
+`;

--- a/frontend/src/pages/restartPage/__tests__/__snapshots__/RestartPageContainer.test.tsx.snap
+++ b/frontend/src/pages/restartPage/__tests__/__snapshots__/RestartPageContainer.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestartPageContainer renders prompt correctly 1`] = `
+<h1
+  class="prompt"
+>
+  Right, I need a quick 
+  <span
+    class="green"
+  >
+    nap
+  </span>
+</h1>
+`;

--- a/frontend/src/pages/restartPage/connectivityWarningDialog/ConnectivityWarningDialog.module.css
+++ b/frontend/src/pages/restartPage/connectivityWarningDialog/ConnectivityWarningDialog.module.css
@@ -1,0 +1,78 @@
+.dialog {
+  max-width: 450px;
+  min-height: 300px;
+  width: 95vw;
+}
+
+.dialogTitle {
+  margin: -15px 0 0 0;
+  display: block;
+  font-size: 1.17em;
+  font-weight: bold;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  margin-top: -45px;
+}
+
+.message {
+  composes: text from '../../../globalStyles/Typography.module.css';
+  margin: 0px 70px 30px 70px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.actions {
+  position: relative;
+  width: min(calc(100% - 20px), 450px);
+  margin-top: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.buttons {
+  flex: 1 1;
+  width: 50%;
+  margin-top: auto;
+  padding-bottom: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.continueButtonContainer {
+  flex: 1;
+  display: flex;
+}
+
+.refreshButtonContainer {
+  flex: 1;
+  display: flex;
+}
+
+.skipButtonContainer {
+  flex: 1;
+  display: flex;
+}
+
+.refreshButton {
+  color: var(--green);
+  margin-right: auto;
+  height: 40px;
+}
+
+.skipButton {
+  color: var(--green);
+  margin-left: auto;
+  height: 40px;
+}
+
+.continueButton {
+  color: var(--green);
+  margin: auto;
+  height: 40px;
+}

--- a/frontend/src/pages/restartPage/connectivityWarningDialog/ConnectivityWarningDialog.tsx
+++ b/frontend/src/pages/restartPage/connectivityWarningDialog/ConnectivityWarningDialog.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+
+import Dialog from "../../../components/atoms/dialog/Dialog";
+import Button from "../../../components/atoms/button/Button";
+
+import styles from "./ConnectivityWarningDialog.module.css";
+
+export type Props = {
+  active: boolean;
+  piTopIpAddress: string;
+  shouldMoveAwayFromAp: boolean;
+  onSkip: () => void;
+  onContinue: () => void;
+};
+
+export const getMessage = (shouldMoveAwayFromAp: boolean) => {
+  return (
+    <>
+      <span className={styles.dialogTitle}>{shouldMoveAwayFromAp ? "Reconnect to your Wi-Fi" : "Reconnect to the pi-top network"} </span>
+    </>
+  );
+};
+
+export const getContent = (shouldMoveAwayFromAp: boolean) => {
+  if (shouldMoveAwayFromAp) {
+    return (
+      <>
+        You've connected your pi-top to Wi-Fi but this computer is still on the pi-top's hotspot.
+        <br></br>
+        <br></br>
+        Please switch this computer to the Wi-Fi you chose for your pi-top and click refresh below.
+      </>
+    )
+  }
+  return (
+    <>
+      After your pi-top restarts, you will need to reconnect your computer to the 'pi-top-XXXX' Wi-Fi network to finish onboarding.
+      <br></br>
+      <br></br>
+      This page may not update until you have reconnected to the network.
+    </>
+  )
+}
+
+export default ({
+  active,
+  piTopIpAddress,
+  shouldMoveAwayFromAp,
+  onSkip,
+  onContinue,
+}: Props) => {
+
+  const url = "http://" + piTopIpAddress + "/onboarding/reboot";
+
+  return (
+    <Dialog active={active} message={getMessage(shouldMoveAwayFromAp)} className={styles.dialog} testId="connectivity-dialog">
+      <div className={styles.content}>
+        <div className={styles.message}>
+          {getContent(shouldMoveAwayFromAp)}
+        </div>
+
+        <div className={styles.buttons}>
+          {shouldMoveAwayFromAp ?
+            <>
+            <div className={styles.refreshButtonContainer}>
+              <Button className={styles.refreshButton} unstyled onClick={() => window.open(url, "_self")} >
+                Refresh
+              </Button>
+            </div>
+
+            <div className={styles.skipButtonContainer}>
+              <Button className={styles.skipButton} unstyled onClick={() => onSkip()}>
+                Skip
+              </Button>
+            </div>
+            </>
+        : <>
+          <div className={styles.continueButtonContainer}>
+            <Button className={styles.continueButton} unstyled onClick={() => onContinue()}>
+              Continue
+            </Button>
+          </div>
+          </>
+        }
+        </div>
+
+      </div>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/restartPage/connectivityWarningDialog/__tests__/ConnectivityWarningDialog.test.tsx
+++ b/frontend/src/pages/restartPage/connectivityWarningDialog/__tests__/ConnectivityWarningDialog.test.tsx
@@ -1,0 +1,140 @@
+import React, { ReactNode } from "react";
+import ReactDom from "react-dom";
+import {
+  render,
+  fireEvent,
+  BoundFunction,
+  GetByBoundAttribute,
+  QueryByText,
+  GetByText,
+  RenderResult,
+  QueryByBoundAttribute,
+  wait,
+} from "@testing-library/react";
+
+import ConnectivityWarningDialog, { Props, getContent, getMessage } from "../ConnectivityWarningDialog";
+
+const originalCreatePortal = ReactDom.createPortal;
+
+window.open = jest.fn();
+
+describe("ConnectivityWarningDialog", () => {
+  let defaultProps: Props;
+  let moveAwayFromApDialog: HTMLElement;
+  let queryByText: BoundFunction<QueryByText>;
+  let getByText: BoundFunction<GetByText>;
+  let queryByTestId: BoundFunction<QueryByBoundAttribute>;
+  let queryByAltText: BoundFunction<QueryByBoundAttribute>;
+  let queryByLabelText: BoundFunction<QueryByBoundAttribute>;
+  let getByLabelText: BoundFunction<GetByBoundAttribute>;
+  let rerender: RenderResult["rerender"];
+
+  const ipAddress = "1.1.1.1";
+
+  beforeEach(() => {
+    defaultProps = {
+      active: true,
+      piTopIpAddress: ipAddress,
+      onSkip: jest.fn(),
+      onContinue: jest.fn(),
+      shouldMoveAwayFromAp: true,
+    };
+
+    ReactDom.createPortal = jest.fn();
+    const createPortalMock = ReactDom.createPortal as jest.Mock;
+    createPortalMock.mockImplementation((element: ReactNode) => element)(
+      ({
+        container: moveAwayFromApDialog,
+        queryByText,
+        queryByTestId,
+        queryByAltText,
+        queryByLabelText,
+        getByLabelText,
+        getByText,
+        rerender,
+      } = render(<ConnectivityWarningDialog {...defaultProps} />))
+    );
+  });
+  afterEach(() => {
+    ReactDom.createPortal = originalCreatePortal;
+  });
+
+  describe("when user should switch networks", () =>{
+    it("renders the correct message", () => {
+      const content = getMessage(true);
+      expect(content).toMatchSnapshot();
+    });
+
+    it("renders the correct content", () => {
+      const content = getContent(true);
+      expect(content).toMatchSnapshot();
+    });
+
+    it("renders Refresh button", () => {
+      expect(queryByText("Refresh")).toBeInTheDocument();
+    });
+
+    it("renders Skip button", () => {
+      expect(queryByText("Skip")).toBeInTheDocument();
+    });
+
+    it("doesn't render the Continue button", () => {
+      expect(queryByText("Continue")).not.toBeInTheDocument();
+    });
+
+
+    it("onSkip is called when Skip button is pressed", () => {
+      fireEvent.click(getByText("Skip"));
+      expect(defaultProps.onSkip).toHaveBeenCalled();
+    });
+
+    it("redirects to IP when Refresh button is pressed", async () => {
+      fireEvent.click(getByText("Refresh"));
+      await wait();
+      expect(window.open).toHaveBeenNthCalledWith(
+        1,
+        "http://" + ipAddress + "/onboarding/reboot",
+        "_self"
+      )
+    });
+  })
+
+  describe("when user only connection mode is through AP", () =>{
+    beforeEach(()=>{
+      defaultProps = {
+        ...defaultProps,
+        shouldMoveAwayFromAp: false,
+      };
+
+      rerender(<ConnectivityWarningDialog {...defaultProps} />);
+    })
+
+    it("renders the correct message", () => {
+      const content = getMessage(false);
+      expect(content).toMatchSnapshot();
+    });
+
+    it("renders the correct content", () => {
+      const content = getContent(false);
+      expect(content).toMatchSnapshot();
+    });
+
+    it("renders Continue button", () => {
+      expect(queryByText("Continue")).toBeInTheDocument();
+    });
+
+    it("doesn't render the Skip button", () => {
+      expect(queryByText("Skip")).not.toBeInTheDocument();
+    });
+
+    it("doesn't render the Skip button", () => {
+      expect(queryByText("Skip")).not.toBeInTheDocument();
+    });
+
+    it("onContinue is called when Continue button is pressed", () => {
+      fireEvent.click(getByText("Continue"));
+      expect(defaultProps.onContinue).toHaveBeenCalled();
+    });
+  })
+
+});

--- a/frontend/src/pages/restartPage/connectivityWarningDialog/__tests__/__snapshots__/ConnectivityWarningDialog.test.tsx.snap
+++ b/frontend/src/pages/restartPage/connectivityWarningDialog/__tests__/__snapshots__/ConnectivityWarningDialog.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectivityWarningDialog when user only connection mode is through AP renders the correct content 1`] = `
+<React.Fragment>
+  After your pi-top restarts, you will need to reconnect your computer to the 'pi-top-XXXX' Wi-Fi network to finish onboarding.
+  <br />
+  <br />
+  This page may not update until you have reconnected to the network.
+</React.Fragment>
+`;
+
+exports[`ConnectivityWarningDialog when user only connection mode is through AP renders the correct message 1`] = `
+<React.Fragment>
+  <span
+    className="dialogTitle"
+  >
+    Reconnect to the pi-top network
+     
+  </span>
+</React.Fragment>
+`;
+
+exports[`ConnectivityWarningDialog when user should switch networks renders the correct content 1`] = `
+<React.Fragment>
+  You've connected your pi-top to Wi-Fi but this computer is still on the pi-top's hotspot.
+  <br />
+  <br />
+  Please switch this computer to the Wi-Fi you chose for your pi-top and click refresh below.
+</React.Fragment>
+`;
+
+exports[`ConnectivityWarningDialog when user should switch networks renders the correct message 1`] = `
+<React.Fragment>
+  <span
+    className="dialogTitle"
+  >
+    Reconnect to your Wi-Fi
+     
+  </span>
+</React.Fragment>
+`;

--- a/frontend/src/services/configureLanding.ts
+++ b/frontend/src/services/configureLanding.ts
@@ -1,0 +1,5 @@
+import api from "./api";
+
+export default async function configureLanding() {
+  await api.post(`/configure-landing`, {});
+}

--- a/frontend/src/services/isOnOpenboxSession.ts
+++ b/frontend/src/services/isOnOpenboxSession.ts
@@ -1,0 +1,6 @@
+import api from "./api";
+
+export default async function isOnOpenboxSession() {
+  const response = await api.get(`/is-on-openbox-session`);
+  return response.data.isOnOpenboxSession;
+}

--- a/frontend/src/services/stopOnboardingAutostart.ts
+++ b/frontend/src/services/stopOnboardingAutostart.ts
@@ -1,0 +1,5 @@
+import api from "./api";
+
+export default async function stopOnboardingAutostart() {
+  await api.post(`/stop-onboarding-autostart`, {});
+}

--- a/frontend/src/types/Page.ts
+++ b/frontend/src/types/Page.ts
@@ -18,6 +18,7 @@ export enum PageRoute {
   Language = "/onboarding/language",
   Registration = "/onboarding/registration",
   Finish = "/onboarding/finish",
+  RestartPage = "/onboarding/restart",
   Links = "/landing/links",
-  LandingSplash = "/landing"
+  LandingSplash = "/landing",
 }

--- a/pt_os_web_portal/backend/routes.py
+++ b/pt_os_web_portal/backend/routes.py
@@ -26,6 +26,7 @@ from .helpers.about import about_device
 from .helpers.build import os_build_info
 from .helpers.finalise import (
     available_space,
+    configure_landing,
     deprioritise_openbox_session,
     disable_ap_mode,
     do_firmware_update,
@@ -33,10 +34,12 @@ from .helpers.finalise import (
     enable_further_link_service,
     enable_pt_miniscreen,
     fw_update_is_due,
+    is_on_openbox_session,
     reboot,
     restore_files,
     should_switch_network,
     stop_first_boot_app_autostart,
+    stop_onboarding_autostart,
     update_eeprom,
 )
 from .helpers.keyboard import (
@@ -351,10 +354,24 @@ def get_available_space():
     return abort_on_no_data(available_space())
 
 
+@app.route("/configure-landing", methods=["POST"])
+def post_configure_landing():
+    logger.debug("Route '/configure-landing'")
+    configure_landing()
+    return "OK"
+
+
 @app.route("/deprioritise-openbox-session", methods=["POST"])
 def post_deprioritise_openbox_session():
     logger.debug("Route '/deprioritise-openbox-session'")
     deprioritise_openbox_session()
+    return "OK"
+
+
+@app.route("/stop-onboarding-autostart", methods=["POST"])
+def post_stop_onboarding_autostart():
+    logger.debug("Route '/stop-onboarding-autostart'")
+    stop_onboarding_autostart()
     return "OK"
 
 
@@ -597,6 +614,12 @@ def get_vnc_wpa_gui_url():
     except Exception:
         url = ""
     return jdumps({"url": url})
+
+
+@app.route("/is-on-openbox-session", methods=["GET"])
+def get_is_on_openbox_session():
+    logger.debug("Route '/is-on-openbox-session'")
+    return jdumps({"isOnOpenboxSession": is_on_openbox_session()})
 
 
 @app.route("/vnc-desktop-url", methods=["GET"])


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-411) |


#### Main changes
- Show restart page for devices with onboarding to allow them to enable missing services and reboot their devices.
  - Re-add restart page component, which was deleted in  https://github.com/pi-top/pi-topOS-Web-Portal/pull/485
  - Re-add some routes required for restart page to work properly.
- Add pt-unattended-upgrades as dependency so it's installed when web-portal is updated for them. New versions of web-portal will already install this package since we changed how we calculate the dependencies.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
