### PR TITLE
Add onboarding miniscreen app

### DIFF
--- a/debian/pt-os-web-portal.postinst
+++ b/debian/pt-os-web-portal.postinst
@@ -18,14 +18,14 @@ is_installed() {
 }
 
 case "$1" in
-  configure)
+configure)
 	# if network-manager-gnome was manually installed, skip
-	if [ $(apt show network-manager-gnome 2>/dev/null| grep APT-Manual-Installed | awk '{print $2}') = "no" ]; then
+	if [ $(apt show network-manager-gnome 2>/dev/null | grep APT-Manual-Installed | awk '{print $2}') = "no" ]; then
 		# prevent nm-applet from auto starting if pt-os-web-portal is the only package that has network-manager-gnome as a dependency
 		PACKAGES=$(get_reverse_dependencies network-manager-gnome)
 		if [[ $PACKAGES == "pt-os-web-portal" ]]; then
 			if grep -q -v "Hidden=true" /etc/xdg/autostart/nm-applet.desktop; then
-				echo "Hidden=true" >> /etc/xdg/autostart/nm-applet.desktop
+				echo "Hidden=true" >>/etc/xdg/autostart/nm-applet.desktop
 			fi
 		fi
 	fi
@@ -44,13 +44,27 @@ case "$1" in
 		/usr/lib/pt-os-web-portal/handle-service-restart-in-policy add NetworkManager.service
 	fi
 
-  ;;
+	LAST_UPDATE_FOLDER="/var/lib/pt-os-web-portal"
+	STATE_FILE="${LAST_UPDATE_FOLDER}/state.cfg"
 
-\
-  abort-upgrade | abort-remove | abort-deconfigure | try-restart | triggered) ;;
+ 	# if upgrading from a previous version...
+	if [ ! -z "$2" ]; then
+		# and the state file doesn't exist (probably upgrading during onboarding)
+		if [ ! -f "${STATE_FILE}" ]; then
+			# the miniscreen onboarding app should run ....
+			mkdir -p "${LAST_UPDATE_FOLDER}"
+			cat >"${STATE_FILE}" <<EOL
+[onboarding]
+start_miniscreen_app = true
+EOL
+		fi
+	fi
 
-\
-	*)
+	;;
+
+abort-upgrade | abort-remove | abort-deconfigure | try-restart | triggered) ;;
+
+*)
 	echo "postinst called with unknown argument \`$1'" >&2
 	exit 1
 	;;

--- a/debian/pt-os-web-portal.postinst
+++ b/debian/pt-os-web-portal.postinst
@@ -47,13 +47,17 @@ configure)
 	LAST_UPDATE_FOLDER="/var/lib/pt-os-web-portal"
 	STATE_FILE="${LAST_UPDATE_FOLDER}/state.cfg"
 
- 	# if upgrading from a previous version...
-	if [ ! -z "$2" ]; then
-		# and the state file doesn't exist (probably upgrading during onboarding)
+	# only when upgrading the pt-os-web-portal package...
+	# ($2 is the old version when calling this postinst script)
+	if [ -n "$2" ]; then
+		# web-portal won't have a state file unless the pi-top has already been onboarded
 		if [ ! -f "${STATE_FILE}" ]; then
-			# the miniscreen onboarding app should run ....
+			# create a state file to ensure the onboarding and miniscreen onboarding assistant app runs
 			mkdir -p "${LAST_UPDATE_FOLDER}"
 			cat >"${STATE_FILE}" <<EOL
+[app]
+onboarded = false
+
 [onboarding]
 start_miniscreen_app = true
 EOL

--- a/pt_os_web_portal/app.py
+++ b/pt_os_web_portal/app.py
@@ -1,14 +1,22 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from os import environ
 
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
 from pitop.common.common_names import DeviceName
+from pitop.common.pt_os import is_pi_top_os
 from pitop.system import device_type
 
+from pt_os_web_portal.backend.helpers.finalise import disable_ap_mode
+
+from . import state
 from .backend import create_app
 from .connection_manager import ConnectionManager
 from .device_registration.listener import setup_device_registration_event_handlers
+from .miniscreen_onboarding_assistant.onboarding_assistant_app import (
+    OnboardingAssistantApp,
+)
 from .os_updater import OSUpdater
 
 logger = logging.getLogger(__name__)
@@ -31,6 +39,7 @@ class App:
             handler_class=WebSocketHandler,
         )
 
+        self.miniscreen_onboarding = None
         self.connection_manager = None
 
         if self.device == DeviceName.pi_top_4.value:
@@ -38,6 +47,22 @@ class App:
 
     def start(self):
         self.os_updater.start()
+
+        if (
+            is_pi_top_os()
+            and state.get("app", "onboarded", fallback="false") == "false"
+        ):
+            logger.info("Onboarding not completed ...")
+            if self.device == DeviceName.pi_top_4.value:
+                logger.debug("Setting ENV VAR to use miniscreen as system...")
+                environ["PT_MINISCREEN_SYSTEM"] = "1"
+
+                logger.info("Starting miniscreen onboarding application")
+                self.miniscreen_onboarding = OnboardingAssistantApp()
+                self.miniscreen_onboarding.start()
+            else:
+                logger.info("Not a pi-top[4] - disabling AP mode")
+                disable_ap_mode()
 
         setup_device_registration_event_handlers()
 
@@ -56,6 +81,8 @@ class App:
         with ThreadPoolExecutor() as executor:
             for stop_func in [
                 self.os_updater.stop,
+                lambda: self.miniscreen_onboarding
+                and self.miniscreen_onboarding.stop(),
                 lambda: self.connection_manager and self.connection_manager.stop(),
                 stop_wsgi_server,
             ]:

--- a/pt_os_web_portal/app.py
+++ b/pt_os_web_portal/app.py
@@ -48,25 +48,31 @@ class App:
     def start(self):
         self.os_updater.start()
 
-        if (
+        is_onboarding = (
             is_pi_top_os()
             and state.get("app", "onboarded", fallback="false") == "false"
-        ):
+        )
+
+        if is_onboarding:
             logger.info("Onboarding not completed ...")
-            if (
-                self.device == DeviceName.pi_top_4.value
-                and state.get("onboarding", "start_miniscreen_app", fallback="false")
+
+            is_pi_top_4 = self.device == DeviceName.pi_top_4.value
+            should_start_miniscreen_app = (
+                state.get("onboarding", "start_miniscreen_app", fallback="false")
                 == "true"
-            ):
-                environ["PT_MINISCREEN_SYSTEM"] = "1"
+            )
+
+            if not is_pi_top_4:
+                logger.info("Not a pi-top[4] - disabling AP mode")
+                disable_ap_mode()
+
+            if is_pi_top_4 and should_start_miniscreen_app:
                 logger.debug("Setting ENV VAR to use miniscreen as system...")
+                environ["PT_MINISCREEN_SYSTEM"] = "1"
 
                 logger.info("Starting miniscreen onboarding application")
                 self.miniscreen_onboarding = OnboardingAssistantApp()
                 self.miniscreen_onboarding.start()
-            else:
-                logger.info("Not a pi-top[4] - disabling AP mode")
-                disable_ap_mode()
 
         setup_device_registration_event_handlers()
 

--- a/pt_os_web_portal/app.py
+++ b/pt_os_web_portal/app.py
@@ -53,9 +53,13 @@ class App:
             and state.get("app", "onboarded", fallback="false") == "false"
         ):
             logger.info("Onboarding not completed ...")
-            if self.device == DeviceName.pi_top_4.value:
-                logger.debug("Setting ENV VAR to use miniscreen as system...")
+            if (
+                self.device == DeviceName.pi_top_4.value
+                and state.get("onboarding", "start_miniscreen_app", fallback="false")
+                == "true"
+            ):
                 environ["PT_MINISCREEN_SYSTEM"] = "1"
+                logger.debug("Setting ENV VAR to use miniscreen as system...")
 
                 logger.info("Starting miniscreen onboarding application")
                 self.miniscreen_onboarding = OnboardingAssistantApp()

--- a/pt_os_web_portal/backend/helpers/finalise.py
+++ b/pt_os_web_portal/backend/helpers/finalise.py
@@ -79,6 +79,7 @@ def stop_onboarding_autostart() -> None:
     logger.debug("Function: stop_onboarding_autostart()")
     try:
         state.set("app", "onboarded", "true")
+        state.set("onboarding", "start_miniscreen_app", "false")
         remove("/etc/xdg/autostart/pt-os-setup.desktop")
     except FileNotFoundError:
         logger.debug("stop_onboarding_autostart: Onboarding already disabled")
@@ -90,6 +91,7 @@ def stop_first_boot_app_autostart() -> None:
     logger.debug("Function: stop_first_boot_app_autostart()")
     try:
         state.set("app", "onboarded", "true")
+        state.set("onboarding", "start_miniscreen_app", "false")
         disable_first_boot_app()
     except Exception as e:
         logger.error(f"stop_first_boot_app_autostart: {e}")


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
- Re-add onboarding miniscreen app. The app should only start after the package is upgraded during onboarding, and on every boot until the device is onboarded.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
